### PR TITLE
Enforce 64-bit build requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.18)
 
 project(Worldforge)
 
+if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+    message(FATAL_ERROR "Worldforge requires a 64-bit build.")
+endif()
+
 # Meta data
 set(DESCRIPTION "The Worldforge project.")
 # Setting this at the top level prevents the libs from installing any artifacts.


### PR DESCRIPTION
## Summary
- fail configuration when not targeting a 64-bit environment

## Testing
- `cmake -B build` (fails: missing dependencies)
- `cmake -B build32` with `CMAKE_SIZEOF_VOID_P` forced to 4 → fails with "Worldforge requires a 64-bit build."

------
https://chatgpt.com/codex/tasks/task_e_68abc9a43710832d9fe2d3e93790487b