### PR TITLE
Use 64-bit timestamps and chrono

### DIFF
--- a/apps/ember/src/services/server/TransferInfoStringSerializer.cpp
+++ b/apps/ember/src/services/server/TransferInfoStringSerializer.cpp
@@ -26,6 +26,7 @@
 #include <Atlas/Message/QueuedDecoder.h>
 #include <Atlas/Codecs/Bach.h>
 #include <Atlas/Formatter.h>
+#include <cstdint>
 
 namespace Ember {
 
@@ -81,11 +82,11 @@ bool TransferInfoStringSerializer::deserialize(TransferInfoStore& infoObjects, s
 							Atlas::Message::MapType info = infoElement.asMap();
 							const std::string& host = info["host"].asString();
 							auto port = info["port"].asInt();
-							const std::string& key = info["key"].asString();
-							const std::string& entityId = info["entityid"].asString();
-							const std::string& avatarName = info["avatarname"].asString();
-							auto timestamp = info["timestamp"].asInt();
-							infoObjects.emplace_back(avatarName, WFMath::TimeStamp::epochStart() + WFMath::TimeDiff((long) timestamp), Eris::TransferInfo(host, (int) port, key, entityId));
+                                                        const std::string& key = info["key"].asString();
+                                                        const std::string& entityId = info["entityid"].asString();
+                                                        const std::string& avatarName = info["avatarname"].asString();
+                                                        std::int64_t timestamp = info["timestamp"].asInt();
+                                                        infoObjects.emplace_back(avatarName, WFMath::TimeStamp::epochStart() + WFMath::TimeDiff(timestamp), Eris::TransferInfo(host, (int) port, key, entityId));
 						}
 					}
 				}

--- a/apps/ember/tests/TestTerrain.cpp
+++ b/apps/ember/tests/TestTerrain.cpp
@@ -32,6 +32,7 @@
 #include <sigc++/trackable.h>
 
 #include <condition_variable>
+#include <cstdint>
 
 using namespace Ember::OgreView;
 using namespace Ember::OgreView::Terrain;
@@ -192,9 +193,9 @@ public:
 
 	}
 
-	bool hasElapsed(long milliseconds) {
-		return (WFMath::TimeStamp::now() - startTime).milliseconds() > milliseconds;
-	}
+        bool hasElapsed(std::int64_t milliseconds) {
+                return (WFMath::TimeStamp::now() - startTime).milliseconds() > milliseconds;
+        }
 
 };
 
@@ -222,7 +223,7 @@ public:
 			mCompletedCount(0) {
 	}
 
-	int waitForCompletion(long milliseconds) {
+        int waitForCompletion(std::int64_t milliseconds) {
 		std::unique_lock <std::mutex> lock(mMutex);
 		if (mCompletedCount) {
 			return true;

--- a/libs/eris/src/Eris/MetaQuery.cpp
+++ b/libs/eris/src/Eris/MetaQuery.cpp
@@ -59,8 +59,8 @@ void MetaQuery::dispatch() {
 	_meta.dispatch();
 }
 
-long MetaQuery::getElapsed() {
-	return (TimeStamp::now() - _stamp).milliseconds();
+std::int64_t MetaQuery::getElapsed() {
+        return (TimeStamp::now() - _stamp).milliseconds();
 }
 
 void MetaQuery::handleFailure(const std::string& msg) {

--- a/libs/eris/src/Eris/MetaQuery.h
+++ b/libs/eris/src/Eris/MetaQuery.h
@@ -4,6 +4,7 @@
 #include "BaseConnection.h"
 
 #include <wfmath/timestamp.h>
+#include <cstdint>
 
 namespace Eris {
 
@@ -32,8 +33,8 @@ public:
 
 	size_t getServerIndex() const;
 
-	/// Access the elapsed time (in milliseconds) since the query was issued
-	long getElapsed();
+        /// Access the elapsed time (in milliseconds) since the query was issued
+        std::int64_t getElapsed();
 
 	bool isComplete() const;
 

--- a/libs/eris/tests/Metaserver_unittest.cpp
+++ b/libs/eris/tests/Metaserver_unittest.cpp
@@ -189,8 +189,8 @@ void MetaQuery::handleFailure(const std::string& msg) {
 void MetaQuery::handleTimeout(const std::string&) {
 }
 
-long MetaQuery::getElapsed() {
-	return 0L;
+std::int64_t MetaQuery::getElapsed() {
+        return 0LL;
 }
 
 BaseConnection::BaseConnection(boost::asio::io_context& io_service, std::string cnm,

--- a/libs/wfmath/src/wfmath/timestamp.h
+++ b/libs/wfmath/src/wfmath/timestamp.h
@@ -29,6 +29,7 @@
 #include <wfmath/const.h>
 #include <algorithm> // For std::pair
 #include <iosfwd>
+#include <cstdint>
 
 /** Timing related primitives in a portable fashion - note this is for interval / elapsed
 time measurement, not displaying a human readable time. */
@@ -52,14 +53,14 @@ class TimeStamp;
  * It also has the full set of comparison * operators (<, <=, >, >=, ==, !=).
  **/
 class TimeDiff {
-	TimeDiff(long sec, long usec, bool is_valid);
+        TimeDiff(std::int64_t sec, std::int64_t usec, bool is_valid);
 
 public:
 	/// construct an uninitialized TimeDiff
 	TimeDiff() : m_isvalid(false) {}
 
 	/// construct a TimeDiff of a given number of milliseconds
-	TimeDiff(long msec);
+        TimeDiff(std::int64_t msec);
 	// default copy constructor is fine
 
 	/// Get the value of a TimeDiff in milliseconds
@@ -67,10 +68,10 @@ public:
 	 * WARNING! This function does not check for overflow, if the
 	 * number of milliseconds is large
 	 **/
-	long milliseconds() const;
+        std::int64_t milliseconds() const;
 
 	/// Get the value of a TimeDiff in (seconds, microseconds)
-	std::pair<long, long> full_time() const { return std::make_pair(m_sec, m_usec); }
+        std::pair<std::int64_t, std::int64_t> full_time() const { return std::make_pair(m_sec, m_usec); }
 
 	bool isValid() const { return m_isvalid; }
 
@@ -110,7 +111,7 @@ public:
 
 private:
 	bool m_isvalid;
-	long m_sec, m_usec;
+        std::int64_t m_sec, m_usec;
 };
 
 inline bool operator>(const TimeDiff& a, const TimeDiff& b) { return b < a; }
@@ -129,19 +130,13 @@ inline bool operator!=(const TimeDiff& a, const TimeDiff& b) { return !(b == a);
  **/
 class TimeStamp {
 private:
-#ifdef _WIN32
-	// We roll our own timeval... may only need to be done for mingw32.
-	struct {
-	  long tv_sec;	/* seconds */
-	  long tv_usec;	/* microseconds */
-	} _val;
-#else
-	// POSIX, BeOS, ....
-	struct timeval _val{};
-#endif
-	bool _isvalid;
+        struct {
+                std::int64_t tv_sec;  /* seconds */
+                std::int64_t tv_usec; /* microseconds */
+        } _val{};
+        bool _isvalid;
 
-	TimeStamp(long sec, long usec, bool isvalid);
+        TimeStamp(std::int64_t sec, std::int64_t usec, bool isvalid);
 
 public:
 	/// Construct an uninitialized TimeStamp


### PR DESCRIPTION
## Summary
- adopt `std::int64_t` for timestamp storage and calculations
- base timestamp arithmetic on `std::chrono` durations
- adjust callers and tests for the wider time representation

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost; could not find cppunit configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abc99e177c832d8456672aa2d16857