### PR TITLE
Allow configuring window size

### DIFF
--- a/apps/ember/src/components/ogre/OgreSetup.cpp
+++ b/apps/ember/src/components/ogre/OgreSetup.cpp
@@ -273,12 +273,18 @@ void OgreSetup::configure() {
 		parseWindowGeometry(mRoot->getRenderSystem()->getConfigOptions(), width, height, fullscreen);
 
 
-	} catch (const std::exception& ex) {
-		logger->error("Got exception when setting up OGRE: {}", ex.what());
-	}
+        } catch (const std::exception& ex) {
+                logger->error("Got exception when setting up OGRE: {}", ex.what());
+        }
 
+        if (configService.hasItem("graphics", "window_width")) {
+                width = static_cast<unsigned int>(configService.getValue("graphics", "window_width"));
+        }
+        if (configService.hasItem("graphics", "window_height")) {
+                height = static_cast<unsigned int>(configService.getValue("graphics", "window_height"));
+        }
 
-	bool handleOpenGL = false;
+        bool handleOpenGL = false;
 #ifdef __APPLE__
 	handleOpenGL = true;
 #endif

--- a/apps/ember/tools/ember.tmpl.conf
+++ b/apps/ember/tools/ember.tmpl.conf
@@ -40,6 +40,11 @@ lodbias = "100.0"
 #the maximum render distance that client renders till as a percentage of the maximum clip distance.
 renderdistance = "100.0"
 
+# The initial width of the window in pixels.
+window_width = 1280
+# The initial height of the window in pixels.
+window_height = 720
+
 [ogre]
 #if set to true, the application will be double buffered, which means that everything is rendered into a separate backbuffer, which is then copied to the main screen buffer when appropriate. This will in some cases reduce tearing.
 doublebuffered = true


### PR DESCRIPTION
## Summary
- expose `window_width` and `window_height` in the default config
- read optional window size overrides before window creation

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cppunit" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68abcdbe2c28832d96862f4102ed9614