### PR TITLE
docs: document prebuilt CI artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ This step also requires ImageMagick to be installed.
 If you only want to build the server or the client you can supply these options to the "conan install..." command:
 "-o Worldforge/*:with_client=False" or "-o Worldforge/*:with_server=False".
 
+### Prebuilt CI artifacts
+
+Our continuous integration builds precompiled binaries and packages them as
+`prebuilt/` artifacts. You can download these from the
+[build-all workflow](https://github.com/worldforge/worldforge/actions/workflows/build-all.yml)
+on GitHub Actions. Select a successful run and expand **Artifacts** to find
+the `prebuilt` archive.
+
+Artifacts are published only for workflow runs where all tests pass.
+
 ### CMake < 3.23
 
 If your CMake tool is an earlier version, < 3.23, you can't use the "presets" system with Conan. Instead you have to


### PR DESCRIPTION
## Summary
- explain how to fetch `prebuilt/` artifacts produced by GitHub Actions

## Testing
- `cmake --build --preset conan-release --target check` *(fails: Could not read presets from /workspace/worldforge: File not found: /workspace/worldforge/CMakePresets.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf7a0a9c832da56ce5d72c681741