### PR TITLE
feat: configure prebuilt artifacts

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -120,7 +120,7 @@ jobs:
             -   name: Configure CMake
                 shell: bash
                 #The -DCMAKE_C_FLAGS="-s" will strip all executables, which we want because we want to provide a Snap package
-                run: cmake --preset $PROFILE_CONAN . -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=~/install/usr -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-s" -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON
+                run: cmake --preset $PROFILE_CONAN . -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/prebuilt -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-s" -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON
 
             -   name: Build
                 shell: bash
@@ -134,6 +134,13 @@ jobs:
                     else
                         cmake --build --preset conan-release --parallel 4 --target check
                     fi
+
+            -   name: Archive prebuilt directory
+                if: success()
+                uses: actions/upload-artifact@v4.6.1
+                with:
+                    name: prebuilt
+                    path: ${{ github.workspace }}/prebuilt
 
             -   name: Build AppImage
                 if: env.BUILD_APPIMAGE == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .idea
 !.idea/codeStyles
 build
+prebuilt/
 cmake-*
 CMakeUserPresets.json
 conan_provider.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.18)
 
 project(Worldforge)
 
+option(PREBUILT_DIR "Directory for prebuilt artifacts" "${CMAKE_SOURCE_DIR}/prebuilt")
+set(CMAKE_INSTALL_PREFIX "${PREBUILT_DIR}" CACHE PATH "Install path prefix" FORCE)
+
 if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(FATAL_ERROR "Worldforge requires a 64-bit build.")
 endif()


### PR DESCRIPTION
## Summary
- ignore prebuilt directory in git
- add PREBUILT_DIR option and install prefix in root CMakeLists
- configure workflow to install into prebuilt path and upload it as artifact

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cppunit"; Could not find package configuration file provided by "spdlog")*


------
https://chatgpt.com/codex/tasks/task_e_68abcf681698832dbe49cbcb079f7ea4