### PR TITLE
Enable coverage reports in CI

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -10,8 +10,9 @@ env:
     CONAN_REVISIONS_ENABLED: 1
     CONAN_SCM_TO_CONANDATA: 1
     CONAN_SYSREQUIRES_MODE: enabled
-    PROFILE_CONAN: conan-release
+    PROFILE_CONAN: conan-debug
     CI: 1 #This will turn off a couple of warnings in the build
+    CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
     build:
@@ -78,17 +79,34 @@ jobs:
             -   name: Configure CMake
                 shell: bash
                 #The -DCMAKE_C_FLAGS="-s" will strip all executables, which we want because we want to provide a Snap package
-                run: cmake --preset $PROFILE_CONAN . -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=~/install/usr -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-s" -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON
+                run: cmake --preset $PROFILE_CONAN . -DBUILD_TESTING=ON -DWORLDFORGE_ENABLE_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=~/install/usr -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-s" -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON
 
             -   name: Build
                 shell: bash
-                run: cmake --build --preset conan-release --parallel 4
+                run: cmake --build --preset $PROFILE_CONAN --parallel 4
 
             -   name: Test
                 shell: bash
+                run: ctest --preset $PROFILE_CONAN --output-on-failure
+
+            -   name: Generate coverage report
+                if: runner.os == 'Linux'
+                shell: bash
                 run: |
-                    if [[ "$ImageOS" == "win22" ]]; then
-                        ctest --preset conan-release --output-on-failure
-                    else
-                        cmake --build --preset conan-release --parallel 4 --target check
-                    fi
+                    lcov --directory . --capture --output-file coverage.info
+                    lcov --remove coverage.info '/usr/*' --output-file coverage.info
+                    genhtml coverage.info --output-directory coverage-report
+
+            -   name: Upload coverage artifact
+                if: runner.os == 'Linux'
+                uses: actions/upload-artifact@v4.6.1
+                with:
+                    name: coverage-report
+                    path: coverage-report
+
+            -   name: Upload coverage to Codecov
+                if: runner.os == 'Linux' && env.CODECOV_TOKEN != ''
+                uses: codecov/codecov-action@v4
+                with:
+                    files: coverage.info
+                    token: ${{ env.CODECOV_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ MESSAGE(STATUS "Setting compiler warnings to '${WF_WARNING_FLAGS}'")
 #Do this globally for the whole repo
 add_compile_options(${WF_WARNING_FLAGS})
 
+option(WORLDFORGE_ENABLE_COVERAGE "Enable coverage flags for Debug builds" OFF)
+if (WORLDFORGE_ENABLE_COVERAGE AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        add_compile_options(--coverage)
+        add_link_options(--coverage)
+    endif ()
+endif ()
+
 option(BUILD_TESTING "Should tests always be built; otherwise they will be built when the 'check' target is executed." OFF)
 option(SKIP_EMBER "Skips building the Ember client." OFF)
 option(SKIP_CYPHESIS "Skips building the Cyphesis server." OFF)


### PR DESCRIPTION
## Summary
- add optional coverage flags for Debug builds
- run ctest with coverage in pull-request workflow
- upload lcov reports and optional Codecov integration

## Testing
- `cmake -S . -B build -DWORLDFORGE_ENABLE_COVERAGE=ON -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug` *(failed: Could not find a package configuration file provided by "cppunit"...)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf70b7ec832db2912a8ed6c03d15