### PR TITLE
Add binary version check to package workflow

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -18,7 +18,7 @@ env:
     CI: 1 #This will turn off a couple of warnings in the build
 
 jobs:
-    build:
+    package:
         name: Build on *NIX and Windows
         runs-on: ${{ matrix.os }}
         strategy:
@@ -184,6 +184,21 @@ jobs:
                 run: |
                     echo "Building Snap"
                     cmake --build --preset conan-release  --parallel 4 --target snap-build-cyphesis
+
+            -   name: Verify packaged binaries
+                if: ${{ success() }}
+                shell: bash
+                run: |
+                    set -e
+                    if ls "$HOME"/install/usr/bin/* >/dev/null 2>&1; then
+                        for bin in "$HOME"/install/usr/bin/*; do
+                            echo "Checking $bin"
+                            "$bin" --version >/dev/null 2>&1 || "$bin" -v >/dev/null 2>&1 || "$bin" version >/dev/null 2>&1 || { echo "$bin failed to report version"; exit 1; }
+                        done
+                    else
+                        echo "No executables found in $HOME/install/usr/bin"
+                        exit 1
+                    fi
 
             -   name: Upload Snaps to Snapstore
                 if: env.BUILD_SNAP == 'true'


### PR DESCRIPTION
## Summary
- rename build job to `package`
- run each packaged binary with `--version` to ensure executables start

## Testing
- `yamllint .github/workflows/build-all.yml` *(fails: numerous pre-existing style errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf73dea0832dacb8bddfc0c907d4