### PR TITLE
Split build and package workflow jobs

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -18,8 +18,8 @@ env:
     CI: 1 #This will turn off a couple of warnings in the build
 
 jobs:
-    build:
-        name: Build on *NIX and Windows
+    build-test:
+        name: Build and test on *NIX and Windows
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
@@ -135,6 +135,112 @@ jobs:
                         cmake --build --preset conan-release --parallel 4 --target check
                     fi
 
+    package:
+        name: Package on *NIX and Windows
+        needs: build-test
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ ubuntu-22.04, ubuntu-24.04, windows-2022 ]
+
+        steps:
+            -   uses: actions/checkout@v4.2.2
+                with:
+                  fetch-depth: 0 #We need all history to get proper Git versioning for dev builds.
+
+            -   name: Workaround preset name difference
+                if: runner.os == 'Windows'
+                shell: bash
+                run: echo "PROFILE_CONAN=conan-default" >> $GITHUB_ENV
+
+            -   name: Cache media
+                uses: actions/cache@v4.2.1
+                with:
+                    path: |
+                        ~/install/usr/share/cyphesis/assets
+                    key: worldforge-media
+
+            -   name: Use ccache
+                uses: hendrikmuhs/ccache-action@v1.2
+                with:
+                    key: ${{ github.job }}-${{ matrix.os }}
+
+            -   name: "Install packages"
+                uses: awalsh128/cache-apt-pkgs-action@v1.4.3
+                if: runner.os == 'Linux'
+                with:
+                    #Needed for the assets processing step in Cyphesis
+                    packages: imagemagick file rsync libfuse2
+                    version: 1.0
+
+            -   name: Setup environment
+                shell: bash
+                run: |
+                    if [[ "$ImageOS" == "ubuntu22" ]]; then
+                      echo "BUILD_SNAP=true" >> $GITHUB_ENV
+                    fi
+                    if [[ "$ImageOS" == "ubuntu22" ]]; then
+                      echo "BUILD_APPIMAGE=true" >> $GITHUB_ENV
+                    fi
+                    if [[ "$ImageOS" == "win22" ]]; then
+                      echo "BUILD_EMBER_NSIS=true" >> $GITHUB_ENV
+                    fi
+                    export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+
+            -   name: Install Mac tools
+                shell: bash
+                if: runner.os == 'macOS'
+                run: |
+                    brew install autoconf automake
+
+            -   name: Install Windows tools
+                if: runner.os == 'Windows'
+                uses: "GuillaumeFalourd/setup-rsync@v1.2"
+
+            -   name: Install LXD (for Snapcraft)
+                if: env.BUILD_SNAP == 'true'
+                uses: canonical/setup-lxd@v0.1.2
+
+            -   name: Install Snapcraft
+                if: env.BUILD_SNAP == 'true'
+                uses: samuelmeuli/action-snapcraft@v2
+
+            -   uses: actions/setup-python@v5
+                with:
+                    python-version: '3.10'
+                    cache: 'pip'
+
+            -   name: Install Conan
+                shell: bash
+                run: |
+                    pip install -r .github/workflows/requirements.txt
+                    conan profile detect
+                    #Set the default profile to use g++ 17 it it's not detected
+                    sed -i.backup 's/compiler.cppstd=14/compiler.cppstd=17/g' ~/.conan2/profiles/default
+                    conan remote add worldforge https://artifactory.ogenvik.org/artifactory/api/conan/conan-local
+
+            -   name: Have Conan install packages
+                shell: bash
+                run: |
+                    export PATH=~/.local/bin:$PATH
+                    #We've gotten problems with building the Python package because it tries to access /etc/ssl/openssl.cnf on the host machine, which might be in a different format than expected.
+                    #Avoid this by setting OPENSSL_CONF
+                    export OPENSSL_CONF=/dev/null
+                    conan install . -pr default --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True --lockfile-partial
+                    if [[ x"$CONAN_PASSWORD" != "x" && x"$CONAN_LOGIN_USERNAME" != "x" ]]; then
+                      conan remote login worldforge $CONAN_LOGIN_USERNAME -p $CONAN_PASSWORD
+                      conan upload "*" -r worldforge -c
+                    fi
+
+            -   name: Configure CMake
+                shell: bash
+                #The -DCMAKE_C_FLAGS="-s" will strip all executables, which we want because we want to provide a Snap package
+                run: cmake --preset $PROFILE_CONAN . -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=~/install/usr -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS="-s" -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON
+
+            -   name: Build
+                shell: bash
+                run: cmake --build --preset conan-release --parallel 4
+
             -   name: Build AppImage
                 if: env.BUILD_APPIMAGE == 'true'
                 run: |
@@ -148,7 +254,7 @@ jobs:
                     chmod a+x ~/install/AppRun
                     curl -L https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage > appimagetool-x86_64.AppImage
                     chmod a+x appimagetool-x86_64.AppImage
-                    ./appimagetool-x86_64.AppImage -n ~/install                    
+                    ./appimagetool-x86_64.AppImage -n ~/install
 
             -   name: Install all
                 shell: bash
@@ -221,88 +327,4 @@ jobs:
                 with:
                     name: AppImage
                     path: Ember-x86_64.AppImage
-#
-#            -   name: Upload AppImage to amber
-#                if: env.BUILD_APPIMAGE == 'true'
-#                working-directory: ${{github.workspace}}/build/Release
-#                run: rsync -uzcP --no-p ${{github.workspace}}/build/Release/Ember-x86_64.AppImage ${{ secrets.RSYNC_USER }}@amber.worldforge.org::ember-unstable/
 
-
-#  build_windows:
-#    name: Build on Windows
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        os: [ windows-2022 ]
-#
-#    steps:
-#      - uses: actions/checkout@v3.3.0
-#
-#      - name: Cache media
-#        uses: actions/cache@v3.2.3
-#        with:
-#          path: |
-#            ${{github.workspace}}/build_ci/media-0.8.0
-#          key: dev-media
-#
-#      - uses: actions/setup-python@v4
-#        with:
-#          python-version: '3.9'
-#          cache: 'pip'
-#
-#      - name: Install Conan
-#        shell: bash
-#        run: |
-#          pip install -r .github/workflows/requirements.txt
-#          conan --version
-#          conan profile detect
-#          conan remote add worldforge https://artifactory.ogenvik.org/artifactory/api/conan/conan
-#
-#      - name: Set up Cygwin
-#        uses: egor-tensin/setup-cygwin@v4.0.1
-#        with:
-#          packages: rsync
-#
-#      - name: Have Conan install packages
-#        shell: cmd
-#        run: |
-#          conan install . -pr default --build=missing --update
-#          conan remote login worldforge $CONAN_LOGIN_USERNAME -p $CONAN_PASSWORD
-#          conan upload "*" -r worldforge -c
-#
-#      - name: Configure CMake
-#        shell: cmd
-#        run: |
-#          cmake --preset $PROFILE_CONAN -DCMAKE_INSTALL_PREFIX=%USERPROFILE%\install -DVERSION_PACKAGE=latest-DWF_USE_WIDGET_PLUGINS=OFF
-#
-#      - name: Download media
-#        shell: cmd
-#        run: cmake --build --preset $PROFILE_CONAN --target media-download
-#
-#      - name: Build
-#        shell: cmd
-#        run: cmake --build --preset $PROFILE_CONAN --parallel -- /m
-#
-#      - name: Test
-#        shell: cmd
-#        run: ctest --preset $PROFILE_CONAN --output-on-failure
-#
-#      - name: Install
-#        shell: cmd
-#        run: cmake --preset $PROFILE_CONAN --target install
-#
-#      - name: Build NSIS
-#        working-directory: ${{github.workspace}}/build_ci
-#        shell: cmd
-#        run: makensis Ember.nsi
-#
-#      - name: Store NSIS
-#        uses: actions/upload-artifact@v3.1.2
-#        with:
-#          name: NSIS
-#          path: ${{github.workspace}}/build_ci/*.exe
-#
-#      - name: Upload exe to amber
-#        working-directory: ${{github.workspace}}/build_ci
-#        shell: cmd
-#        run: rsync -uzcP --no-p *.exe ${{ secrets.RSYNC_USER }}@amber.worldforge.org::ember-unstable/


### PR DESCRIPTION
## Summary
- separate build and packaging into distinct jobs
- add package job that depends on build-test
- relocate Snap/NSIS/AppImage artifact uploads to package job

## Testing
- `yamllint .github/workflows/build-all.yml`
- `act -n build-test` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf778bdc832d966ee37c31928fb9