### PR TITLE
Add GPL header to Metaserver

### DIFF
--- a/libs/eris/src/Eris/Metaserver.h
+++ b/libs/eris/src/Eris/Metaserver.h
@@ -1,4 +1,23 @@
-// TODO: Copyright stuff
+/*
+ Copyright (C) 2001 Malcolm Walker
+ Copyright (C) 2001-2004 Alistair Riddoch
+ Copyright (C) 2004-2005 James Turner
+ Copyright (C) 2014-2024 Erik Ogenvik
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
 
 #ifndef ERIS_METASERVER_H
 #define ERIS_METASERVER_H


### PR DESCRIPTION
## Summary
- add standard GPL header to `Metaserver.h`

## Testing
- `clang-format -i libs/eris/src/Eris/Metaserver.h` *(fails: invalid number in .clang-format)*
- `cmake -S . -B build` *(fails: missing cppunit and spdlog dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68abd6135648832da5445e83859add42