### PR TITLE
Use mock metaserver in tests

### DIFF
--- a/libs/eris/src/Eris/Metaserver.h
+++ b/libs/eris/src/Eris/Metaserver.h
@@ -78,10 +78,11 @@ public:
 	active at any one time. 10 is a sensible value, too low and querying will
 	take a long time, too high and .... I'm not sure.
 	*/
-	Meta(boost::asio::io_context& io_service,
-		 EventService& eventService,
-		 std::string msv,
-		 unsigned int maxQueries);
+        Meta(boost::asio::io_context& io_service,
+                 EventService& eventService,
+                 std::string msv,
+                 unsigned int maxQueries,
+                 unsigned short metaServerPort = 8453);
 
 	~Meta();
 
@@ -200,8 +201,10 @@ private:
 	const std::string m_clientName;    ///< the name to use when negotiating
 
 	MetaStatus m_status;
-	/// the metaserver query, eg metaserver.worldforge.org
-	const std::string m_metaHost;
+        /// the metaserver query, eg metaserver.worldforge.org
+        const std::string m_metaHost;
+        /// The port used to communicate with the metaserver
+        const std::string m_metaPort;
 
 	typedef std::vector<std::unique_ptr<MetaQuery>> QuerySet;
 	QuerySet m_activeQueries;

--- a/libs/eris/tests/README.md
+++ b/libs/eris/tests/README.md
@@ -1,0 +1,7 @@
+# Eris Tests
+
+The `Metaserver_unittest` test suite uses an embedded mock metaserver. The
+mock listens on a randomly assigned UDP port and emulates enough of the
+metaserver protocol for the library to initialise. Tests inject the mock's
+address into `Eris::Meta`, so no external services are required when running
+the tests locally or in CI.


### PR DESCRIPTION
## Summary
- allow Metaserver to accept a custom port for easier testing
- add a mock metaserver to Metaserver_unittest
- document mock metaserver setup for tests

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread))*

------
https://chatgpt.com/codex/tasks/task_e_68abde8e5c1c832dae6e4f472c25f6fc