### PR TITLE
Optimize ray-terrain intersection

### DIFF
--- a/libs/mercator/tests/Intersecttest.cpp
+++ b/libs/mercator/tests/Intersecttest.cpp
@@ -116,11 +116,18 @@ int main() {
 		return 1;
 	}
 
-	if (!Mercator::Intersect(terrain, WFMath::Point<3>(20.1, segmax + 3, 20.2),
-							 WFMath::Vector<3>(0.0, -50.0, 0.0), intPoint, intNorm, par)) {
-		std::cerr << "vertical ray didnt intersect when it should" << std::endl;
-		return 1;
-	}
+        if (!Mercator::Intersect(terrain, WFMath::Point<3>(20.1, segmax + 3, 20.2),
+                                                         WFMath::Vector<3>(0.0, -50.0, 0.0), intPoint, intNorm, par)) {
+                std::cerr << "vertical ray didnt intersect when it should" << std::endl;
+                return 1;
+        }
+
+        //test horizontal ray above terrain
+        if (Mercator::Intersect(terrain, WFMath::Point<3>(20.1, segmax + 3, 20.2),
+                                                        WFMath::Vector<3>(10.0, 0.0, 10.0), intPoint, intNorm, par)) {
+                std::cerr << "horizontal ray intersected when it should not" << std::endl;
+                return 1;
+        }
 
 	//test each quadrant
 	if (!Mercator::Intersect(terrain, WFMath::Point<3>(20.1, segmax + 3, 20.2),


### PR DESCRIPTION
## Summary
- speed up ray-terrain intersection by caching segment data and checking segment maxima
- add fast path for vertical rays
- cover horizontal rays in intersection tests

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread))*
- `cmake -S libs/mercator -B build` *(fails: Cannot add target-level dependencies to non-existent target "check" and missing Doxygen)*

------
https://chatgpt.com/codex/tasks/task_e_68abe280bdc0832dbb482c39bdab945b