### PR TITLE
Define architecture macros for FastLZ

### DIFF
--- a/apps/cyphesis/src/navigation/README.TXT
+++ b/apps/cyphesis/src/navigation/README.TXT
@@ -6,9 +6,14 @@ Official website: http://www.fastlz.org
 FastLZ is distributed using the MIT license, see file LICENSE
 for details.
 
-FastLZ consists of two files: fastlz.h and fastlz.c. Just add these 
-files to your project in order to use FastLZ. For information on 
+FastLZ consists of two files: fastlz.h and fastlz.c. Just add these
+files to your project in order to use FastLZ. For information on
 compression and decompression routines, see fastlz.h.
+
+fastlz.c includes platform detection macros (e.g., FASTLZ_ARCH_X86_64,
+FASTLZ_ARCH_ARM) that set defaults for common pointer sizes. To support
+another architecture, add a new #elif branch in fastlz.c defining
+FASTLZ_ARCH_<NAME> and the corresponding FASTLZ_POINTER_SIZE.
 
 A simple file compressor called 6pack is included as an example 
 on how to use FastLZ. The corresponding decompressor is 6unpack. 

--- a/apps/cyphesis/src/navigation/fastlz.c
+++ b/apps/cyphesis/src/navigation/fastlz.c
@@ -75,11 +75,38 @@
 #endif
 
 /*
- * FIXME: use preprocessor magic to set this on different platforms!
+ * Platform-dependent constants and integral types.
+ * Defaults cover the most common architectures; extend by adding more
+ * branches in the conditional block below and defining a corresponding
+ * FASTLZ_ARCH_<NAME> macro.
  */
-typedef unsigned char  flzuint8;
-typedef unsigned short flzuint16;
-typedef unsigned int   flzuint32;
+#if defined(__x86_64__) || defined(_M_X64)
+#define FASTLZ_ARCH_X86_64 1
+#define FASTLZ_POINTER_SIZE 8
+#elif defined(__i386__) || defined(_M_IX86)
+#define FASTLZ_ARCH_X86 1
+#define FASTLZ_POINTER_SIZE 4
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define FASTLZ_ARCH_ARM64 1
+#define FASTLZ_POINTER_SIZE 8
+#elif defined(__arm__) || defined(_M_ARM)
+#define FASTLZ_ARCH_ARM 1
+#define FASTLZ_POINTER_SIZE 4
+#else
+#define FASTLZ_ARCH_UNKNOWN 1
+#define FASTLZ_POINTER_SIZE (sizeof(void*))
+#endif
+
+#include <stdint.h>
+typedef uint8_t  flzuint8;
+typedef uint16_t flzuint16;
+typedef uint32_t flzuint32;
+
+/*
+ * To support additional architectures, add a new #elif branch above
+ * and define the appropriate FASTLZ_ARCH_<NAME> and FASTLZ_POINTER_SIZE
+ * values.
+ */
 
 /* prototypes */
 int fastlz_compress(const void* input, int length, void* output);


### PR DESCRIPTION
## Summary
- add FASTLZ_ARCH_* and FASTLZ_POINTER_SIZE macros for common platforms
- document architecture macros in FastLZ README

## Testing
- `/tmp/fastlz_test`
- `cmake ..` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread))*

------
https://chatgpt.com/codex/tasks/task_e_68abe330305c832d9ae0016f1753d2c9