### PR TITLE
Accept Bridge argument in codec negotiation

### DIFF
--- a/libs/atlas/docs/tutorial/example/simple_client.cpp
+++ b/libs/atlas/docs/tutorial/example/simple_client.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
     // The DebugBridge puts all that comes through the codec on cout
     DebugBridge bridge;
     // Do client negotiation with the server
-    Atlas::Net::StreamConnect conn("simple_client", connection);
+    Atlas::Net::StreamConnect conn("simple_client", connection, connection);
 
     std::cout << "Negotiating... " << std::flush;
     // conn.poll() does all the negotiation

--- a/libs/atlas/docs/tutorial/example/simple_server.cpp
+++ b/libs/atlas/docs/tutorial/example/simple_server.cpp
@@ -12,6 +12,7 @@
 // Atlas negotiation
 #include <Atlas/Net/Stream.h>
 #include <Atlas/Codec.h>
+#include <memory>
 // tcp_socket_server, tcp_socket_stream - the iostream socket classes
 #include <skstream/skserver.h>
 // cout, cerr
@@ -34,7 +35,7 @@ int main(int argc, char** argv)
     // The DebugBridge puts all that comes through the codec on cout
     DebugBridge bridge;
     // Do server negotiation for Atlas with the new client
-    Atlas::Net::StreamAccept accepter("simple_server", client);
+    Atlas::Net::StreamAccept accepter("simple_server", client, client);
 
     std::cout << "Negotiating.... " << std::flush;
     // accepter.Poll() does all the negotiation
@@ -50,8 +51,8 @@ int main(int argc, char** argv)
     }
     // Negotiation was successful! 
 
-    // Get the codec that negotation established
-    Atlas::Codec * codec = accepter.getCodec(bridge);
+    // Get the codec that negotiation established
+    auto codec = accepter.getCodec(bridge);
 
     std::cout << "Polling client..." << std::endl;
     

--- a/libs/atlas/docs/tutorial/simple.dox
+++ b/libs/atlas/docs/tutorial/simple.dox
@@ -59,12 +59,12 @@ this for you. Whenever you connect to a server or client, you first enter a
 negotiation stage, in which the client and server decide which Codec to use.
 
 This is done by creating a Net::StreamAccept object in the server or a
-Net::StreamConnect object in the client, passing the name of the server/client,
-the Bridge to be used by the Codec and the stream on which the connection has
-been established. You then repeatedly call the Poll() method of these classes
-until their state is not IN_PROGRESS any more. If negotiation was successful,
-you can retrieve the codec to be used with GetCodec(), and then go on sending
-and receiving messages happily with your peer.
+Net::StreamConnect object in the client, passing the name of the server/client
+and the streams on which the connection has been established. You then
+repeatedly call the Poll() method of these classes until their state is not
+IN_PROGRESS any more. If negotiation was successful, you can retrieve the
+codec to be used with GetCodec(), providing the Bridge instance, and then go on
+sending and receiving messages happily with your peer.
 
 If negotation failed, GetState() will return FAILURE, and you may abort the
 connection and alert the user.
@@ -130,8 +130,8 @@ The code should be pretty straightforward to understand if you have read the
 
 In the above client + server a class called DebugBridge is used. This class is
 not part of Atlas-C++, but rather one that we made ourselves. It is passed to
-the negotiation classes (StreamConnect and StreamAccept) which then pass it on
-to the codec returned by GetCodec().
+the negotiation classes (StreamConnect and StreamAccept) and then passed to the
+codec when calling GetCodec().
 
 DebugBridge simply prints out everything it receives onto cout. The source
 code should be quite easily understandable.

--- a/libs/atlas/docs/tutorial/simple_client.cpp
+++ b/libs/atlas/docs/tutorial/simple_client.cpp
@@ -15,6 +15,7 @@
 #include <Atlas/Net/Stream.h>
 // The DebugBridge
 #include "DebugBridge.h"
+#include <memory>
 
 #include "sockbuf.h"
 
@@ -34,7 +35,7 @@ using namespace Atlas;
 using namespace std;
 
 // This sends a very simple message to c
-void helloWorld(Codec<std::iostream> & c)
+void helloWorld(Atlas::Codec & c)
 {
     cout << "Sending hello world message... " << flush;
     c.streamMessage(Bridge::mapBegin);
@@ -72,7 +73,7 @@ int main(int argc, char** argv)
     // The DebugBridge puts all that comes through the codec on cout
     DebugBridge bridge;
     // Do client negotiation with the server
-    Net::StreamConnect conn("simple_client", connection, &bridge);
+    Net::StreamConnect conn("simple_client", connection, connection);
 
     cout << "Negotiating... " << flush;
     // conn.poll() does all the negotiation
@@ -89,7 +90,7 @@ int main(int argc, char** argv)
     // Negotiation was successful
 
     // Get the codec that negotiation established
-    Codec<std::iostream> * codec = conn.getCodec();
+    auto codec = conn.getCodec(bridge);
 
     // This should always be sent at the beginning of a session
     codec->streamBegin();

--- a/libs/atlas/docs/tutorial/simple_server.cpp
+++ b/libs/atlas/docs/tutorial/simple_server.cpp
@@ -14,6 +14,7 @@
 // The DebugBridge
 #include "DebugBridge.h"
 #include "sockbuf.h"
+#include <memory>
 
 extern "C" {
     #include <stdio.h>
@@ -68,7 +69,7 @@ int main(int argc, char** argv)
     // The DebugBridge puts all that comes through the codec on cout
     DebugBridge bridge;
     // Do server negotiation for Atlas with the new client
-    Net::StreamAccept accepter("simple_server", client, &bridge);
+    Net::StreamAccept accepter("simple_server", client, client);
 
     cout << "Negotiating.... " << flush;
     // accepter.poll() does all the negotiation
@@ -83,8 +84,8 @@ int main(int argc, char** argv)
     }
     // Negotiation was successful! 
 
-    // Get the codec that negotation established
-    Codec<std::iostream> * codec = accepter.getCodec();
+    // Get the codec that negotiation established
+    auto codec = accepter.getCodec(bridge);
 
     cout << "Polling client..." << endl;
     

--- a/libs/atlas/src/Atlas/Net/Stream.cpp
+++ b/libs/atlas/src/Atlas/Net/Stream.cpp
@@ -161,7 +161,6 @@ Atlas::Negotiate::State StreamConnect::getState() {
 	return FAILED;
 }
 
-/// FIXME We should pass in the Bridge here, not at construction time.
 std::unique_ptr<Atlas::Codec> StreamConnect::getCodec(Atlas::Bridge& bridge) {
 	if (m_canPacked) { return std::make_unique<Atlas::Codecs::Packed>(m_inStream, m_outStream, bridge); }
 	if (m_canXML) { return std::make_unique<Atlas::Codecs::XML>(m_inStream, m_outStream, bridge); }
@@ -298,7 +297,6 @@ Atlas::Negotiate::State StreamAccept::getState() {
 	return FAILED;
 }
 
-/// FIXME We should pass in the Bridge here, not at construction time.
 std::unique_ptr<Atlas::Codec> StreamAccept::getCodec(Atlas::Bridge& bridge) {
 	// XXX XXX XXX XXX
 	// should pass an appropriate filterbuf here instead of socket,

--- a/libs/eris/tests/clientConnection.h
+++ b/libs/eris/tests/clientConnection.h
@@ -9,6 +9,7 @@
 #include <Atlas/Objects/Root.h>
 
 #include <deque>
+#include <memory>
 
 class StubServer;
 class Agent;
@@ -73,9 +74,9 @@ private:
     RootDeque m_objDeque;
 
 // Atlas stuff
-    Atlas::Codec* m_codec;
-    Atlas::Net::StreamAccept* m_acceptor;
-    Atlas::Objects::ObjectsEncoder* m_encoder;
+    std::unique_ptr<Atlas::Codec> m_codec;
+    std::unique_ptr<Atlas::Net::StreamAccept> m_acceptor;
+    std::unique_ptr<Atlas::Objects::ObjectsEncoder> m_encoder;
     
     typedef std::map<std::string, Agent*> AgentMap;
     AgentMap m_agents;

--- a/libs/eris/tests/commander.cpp
+++ b/libs/eris/tests/commander.cpp
@@ -9,6 +9,7 @@
 #include <Atlas/Objects/Encoder.h>
 
 #include <cstdio>
+#include <memory>
 
 #pragma warning(disable: 4068)  //unknown pragma
 
@@ -26,7 +27,7 @@ Commander::Commander(StubServer* stub, int fd) :
     m_server(stub),
     m_channel(fd)
 {
-    m_acceptor = new Atlas::Net::StreamAccept("Eris Stub Server", m_channel);
+    m_acceptor = std::make_unique<Atlas::Net::StreamAccept>("Eris Stub Server", m_channel, m_channel);
     m_acceptor->poll(false);
 }
 
@@ -78,11 +79,10 @@ void Commander::negotiate()
 
     case Atlas::Net::StreamAccept::SUCCEEDED:
         m_codec = m_acceptor->getCodec(*this);
-        m_encoder = new Atlas::Objects::ObjectsEncoder(*m_codec);
+        m_encoder = std::make_unique<Atlas::Objects::ObjectsEncoder>(*m_codec);
         m_codec->streamBegin();
 
-        delete m_acceptor;
-        m_acceptor = nullptr;
+        m_acceptor.reset();
         break;
 
     default:

--- a/libs/eris/tests/commander.h
+++ b/libs/eris/tests/commander.h
@@ -8,6 +8,7 @@
 #include <Atlas/Objects/Root.h>
 
 #include <deque>
+#include <memory>
 
 class StubServer;
 
@@ -32,9 +33,9 @@ private:
     StubServer* m_server;
     tcp_socket_stream m_channel;
     
-    Atlas::Codec* m_codec;
-    Atlas::Net::StreamAccept* m_acceptor;
-    Atlas::Objects::ObjectsEncoder* m_encoder;
+    std::unique_ptr<Atlas::Codec> m_codec;
+    std::unique_ptr<Atlas::Net::StreamAccept> m_acceptor;
+    std::unique_ptr<Atlas::Objects::ObjectsEncoder> m_encoder;
     
     typedef std::deque<Atlas::Objects::Root> RootDeque;
     RootDeque m_objDeque;

--- a/libs/eris/tests/controller.cpp
+++ b/libs/eris/tests/controller.cpp
@@ -1,6 +1,7 @@
 #include "controller.h"
 
 #include <cassert>
+#include <memory>
 
 #include <Atlas/Net/Stream.h>
 #include <Atlas/Codec.h>
@@ -28,7 +29,7 @@ Controller::Controller(const char* pipe) :
     assert(m_stream.is_open());
     
 // force synchrous negotation now
-    Atlas::Net::StreamConnect sc("eristest_oob", m_stream);
+    Atlas::Net::StreamConnect sc("eristest_oob", m_stream, m_stream);
     
     // spin (and block) while we negotiate
     do { sc.poll(); } while (sc.getState() == Atlas::Net::StreamConnect::IN_PROGRESS);
@@ -40,7 +41,7 @@ Controller::Controller(const char* pipe) :
     
     Atlas::Bridge* br = this;
     m_codec = sc.getCodec(*br);
-    m_encode = new Atlas::Objects::ObjectsEncoder(*m_codec);
+    m_encode = std::make_unique<Atlas::Objects::ObjectsEncoder>(*m_codec);
     m_codec->streamBegin();
 }
 

--- a/libs/eris/tests/controller.h
+++ b/libs/eris/tests/controller.h
@@ -4,6 +4,7 @@
 #include <Atlas/Objects/ObjectsFwd.h>
 #include <Atlas/Objects/Decoder.h>
 #include <wfmath/point.h>
+#include <memory>
 
 namespace Atlas { class Codec; }
 
@@ -43,8 +44,8 @@ private:
     
     unix_socket_stream m_stream;
 
-    Atlas::Objects::ObjectsEncoder* m_encode;
-    Atlas::Codec* m_codec;
+    std::unique_ptr<Atlas::Objects::ObjectsEncoder> m_encode;
+    std::unique_ptr<Atlas::Codec> m_codec;
 };
 
 #endif // of TEST_CONTROLLER_H


### PR DESCRIPTION
## Summary
- Pass Bridge explicitly when obtaining codecs in `StreamConnect` and `StreamAccept`
- Remove Bridge constructor arguments and update examples and tests
- Modernize tests to use `std::unique_ptr` for codec handling

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON -DSKIP_EMBER=ON -DSKIP_CYPHESIS=ON` *(fails: Could not find cppunit or Microsoft.GSL CMake configs)*

------
https://chatgpt.com/codex/tasks/task_e_68abe33284b0832d856de98c72f08090