### PR TITLE
Implement safe Connection reset and randomize serial

### DIFF
--- a/libs/eris/src/Eris/Connection.h
+++ b/libs/eris/src/Eris/Connection.h
@@ -153,11 +153,14 @@ protected:
 	void setStatus(Status sc) override;
 
 	/// Process failures (to track when reconnection should be permitted)
-	void handleFailure(const std::string& msg) override;
+        void handleFailure(const std::string& msg) override;
 
-	void handleTimeout(const std::string& msg) override;
+        void handleTimeout(const std::string& msg) override;
 
-	void onConnect() override;
+        void onConnect() override;
+
+        /// Reset internal state so the connection instance can be reused.
+        void resetState();
 
 	virtual void objectArrived(Atlas::Objects::Root obj);
 
@@ -181,7 +184,7 @@ protected:
 
 	void dispatchOp(const Atlas::Objects::Operation::RootOperation& op);
 
-	void handleServerInfo(const Atlas::Objects::Operation::RootOperation& op);
+        void handleServerInfo(const Atlas::Objects::Operation::RootOperation& op);
 
 	void onDisconnectTimeout();
 


### PR DESCRIPTION
## Summary
- Clarify disconnect locking semantics and reset state after disconnect
- Add reusable resetState for Connection and use on failure
- Randomize operation serial numbers to avoid reuse after reconnect
- Cover reset and serial generation with new unit tests

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Microsoft.GSL")*
- `g++ -std=c++17 libs/eris/tests/Connection_unittest.cpp ...` *(fails: missing Atlas headers and Boost libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68abe33486f8832dbb42d9233df1945a