### PR TITLE
Use atomic counter for background loading

### DIFF
--- a/apps/ember/src/components/ogre/model/ModelBackgroundLoader.h
+++ b/apps/ember/src/components/ogre/model/ModelBackgroundLoader.h
@@ -27,6 +27,7 @@
 #include "ModelDefinition.h"
 
 #include <Eris/ActiveMarker.h>
+#include <atomic>
 
 namespace Eris {
 class EventService;
@@ -149,7 +150,7 @@ protected:
 	ModelDefinition& mModelDefinition;
 
 
-	int mResourcesBeingLoadingInBackground;
+        std::atomic<std::size_t> mResourcesBeingLoadingInBackground;
 
 	/**
 	 * @brief The current loading state of the instance.


### PR DESCRIPTION
## Summary
- make background resource counter thread-safe using `std::atomic<std::size_t>`
- update background loading operations to use atomic `fetch_add`/`fetch_sub`

## Testing
- `conan install . --output-folder=build --build=missing` *(fails: Unable to find 'cegui/0.8.7@worldforge')*

------
https://chatgpt.com/codex/tasks/task_e_68ad3b2aa7ac832db61d8c58fe5011e3