### PR TITLE
Implement PBR shading with metallic-roughness workflow

### DIFF
--- a/apps/ember/data/assets/common/base/PBR.frag
+++ b/apps/ember/data/assets/common/base/PBR.frag
@@ -1,6 +1,9 @@
 #version 330 core
-in vec3 vNormal;
 in vec2 vUV;
+in vec3 vNormal;
+in vec3 vTangent;
+in vec3 vBitangent;
+in vec3 vViewDir;
 
 out vec4 fragColor;
 
@@ -10,12 +13,85 @@ uniform sampler2D RoughnessMap;
 uniform sampler2D NormalMap;
 uniform sampler2D AOMap;
 
+uniform vec3 lightDir;
+uniform vec3 lightColor;
+
+const float PI = 3.14159265359;
+
+vec3 getNormal()
+{
+    vec3 tangentNormal = texture(NormalMap, vUV).xyz * 2.0 - 1.0;
+    vec3 N = normalize(vNormal);
+    vec3 T = normalize(vTangent);
+    vec3 B = normalize(vBitangent);
+    mat3 TBN = mat3(T, B, N);
+    return normalize(TBN * tangentNormal);
+}
+
+float distributionGGX(vec3 N, vec3 H, float roughness)
+{
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH * NdotH;
+
+    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+    denom = PI * denom * denom;
+    return a2 / denom;
+}
+
+float geometrySchlickGGX(float NdotV, float roughness)
+{
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    float denom = NdotV * (1.0 - k) + k;
+    return NdotV / denom;
+}
+
+float geometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
+{
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotL = max(dot(N, L), 0.0);
+    float ggx2 = geometrySchlickGGX(NdotV, roughness);
+    float ggx1 = geometrySchlickGGX(NdotL, roughness);
+    return ggx1 * ggx2;
+}
+
+vec3 fresnelSchlick(float cosTheta, vec3 F0)
+{
+    return F0 + (1.0 - F0) * pow(1.0 - cosTheta, 5.0);
+}
+
 void main() {
     vec3 albedo = texture(AlbedoMap, vUV).rgb;
     float metallic = texture(MetallicMap, vUV).r;
     float roughness = texture(RoughnessMap, vUV).r;
-    vec3 normal = texture(NormalMap, vUV).xyz * 2.0 - 1.0;
     float ao = texture(AOMap, vUV).r;
-    vec3 color = albedo * ao;
+
+    vec3 N = getNormal();
+    vec3 V = normalize(vViewDir);
+    vec3 L = normalize(lightDir);
+    vec3 H = normalize(V + L);
+
+    float NDF = distributionGGX(N, H, roughness);
+    float G = geometrySmith(N, V, L, roughness);
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+    vec3 kS = F;
+    vec3 kD = (vec3(1.0) - kS) * (1.0 - metallic);
+
+    float NdotL = max(dot(N, L), 0.0);
+
+    vec3 numerator = NDF * G * F;
+    float denominator = 4.0 * max(dot(N, V), 0.0) * NdotL + 0.001;
+    vec3 specular = numerator / denominator;
+
+    vec3 diffuse = kD * albedo / PI;
+    vec3 radiance = lightColor;
+
+    vec3 color = (diffuse + specular) * radiance * NdotL;
+    color *= ao;
+
     fragColor = vec4(color, 1.0);
 }

--- a/apps/ember/data/assets/common/base/PBR.program
+++ b/apps/ember/data/assets/common/base/PBR.program
@@ -1,7 +1,23 @@
 vertex_program PBR/Vp glsl {
     source PBR.vert
+
+    default_params {
+        param_named_auto worldViewProj worldviewproj_matrix
+        param_named_auto world world_matrix
+        param_named_auto cameraPos camera_position
+    }
 }
 
 fragment_program PBR/Fp glsl {
     source PBR.frag
+
+    default_params {
+        param_named AlbedoMap int 0
+        param_named MetallicMap int 1
+        param_named RoughnessMap int 2
+        param_named NormalMap int 3
+        param_named AOMap int 4
+        param_named_auto lightDir light_direction 0
+        param_named_auto lightColor light_diffuse_colour 0
+    }
 }

--- a/apps/ember/data/assets/common/base/PBR.vert
+++ b/apps/ember/data/assets/common/base/PBR.vert
@@ -2,14 +2,31 @@
 layout(location = 0) in vec3 vertexPosition;
 layout(location = 1) in vec3 vertexNormal;
 layout(location = 2) in vec2 vertexUV;
+layout(location = 3) in vec3 vertexTangent;
 
-out vec3 vNormal;
 out vec2 vUV;
+out vec3 vNormal;
+out vec3 vTangent;
+out vec3 vBitangent;
+out vec3 vViewDir;
 
 uniform mat4 worldViewProj;
+uniform mat4 world;
+uniform vec3 cameraPos;
 
 void main() {
-    vNormal = vertexNormal;
+    vec3 worldPos = (world * vec4(vertexPosition, 1.0)).xyz;
+
+    mat3 worldMat3 = mat3(world);
+    vec3 N = normalize(worldMat3 * vertexNormal);
+    vec3 T = normalize(worldMat3 * vertexTangent);
+    vec3 B = normalize(cross(N, T));
+
     vUV = vertexUV;
+    vNormal = N;
+    vTangent = T;
+    vBitangent = B;
+    vViewDir = normalize(cameraPos - worldPos);
+
     gl_Position = worldViewProj * vec4(vertexPosition, 1.0);
 }


### PR DESCRIPTION
## Summary
- expand `PBR.vert` to output tangents, bitangents, and view vectors
- implement metallic-roughness BRDF with normal mapping and light/view vectors in `PBR.frag`
- configure `PBR.program` with matrix, camera, sampler, and light parameters

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cppunit" or "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_68ad3b38eed4832da9a70f827287b3cc