### PR TITLE
Use uintptr_t for debug pointer cast in WrapperBase

### DIFF
--- a/apps/cyphesis/src/pythonbase/WrapperBase.h
+++ b/apps/cyphesis/src/pythonbase/WrapperBase.h
@@ -22,6 +22,7 @@
 #include "common/log.h"
 #include "pycxx/CXX/Extensions.hxx"
 #include <functional>
+#include <cstdint>
 
 template<typename TValue, typename TPythonClass, typename TClassInstance=Py::PythonClassInstance>
 class WrapperBase : public Py::PythonClass<TPythonClass, TClassInstance> {
@@ -154,7 +155,7 @@ protected:
 		auto* self = reinterpret_cast<PyObject*>( o );
 
 #ifdef PYCXX_DEBUG
-		std::cout << "extension_object_new() => self=0x" << std::hex << reinterpret_cast< unsigned long >( self ) << std::dec << std::endl;
+                std::cout << "extension_object_new() => self=0x" << std::hex << reinterpret_cast< std::uintptr_t >( self ) << std::dec << std::endl;
 #endif
 		return self;
 	}


### PR DESCRIPTION
## Summary
- ensure debug pointer output uses `std::uintptr_t`
- include `<cstdint>` for portable pointer printing

## Testing
- `g++ -std=c++17 /tmp/pointer_test.cpp -o /tmp/pointer_test_64 && /tmp/pointer_test_64`
- `g++ -m32 -std=c++17 /tmp/pointer_test.cpp -o /tmp/pointer_test_32` *(fails to run: Exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_68af5288d114832d89d0585bc9dc9221