### PR TITLE
Use uintptr_t for window handles

### DIFF
--- a/apps/ember/src/services/input/Input.cpp
+++ b/apps/ember/src/services/input/Input.cpp
@@ -40,6 +40,7 @@
 
 #include <SDL3/SDL.h>
 
+#include <cstdint>
 #include <sstream>
 #include <spdlog/spdlog.h>
 
@@ -163,13 +164,14 @@ std::string Input::createWindow(unsigned int width, unsigned int height, bool fu
 #ifdef __APPLE__
 	//On OSX we'll tell Ogre to use the current OpenGL context; thus we don't need to return the window id
 #elif defined(_WIN32)
-	HWND hwnd = (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(mMainVideoSurface), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL);
-	if (hwnd) {
-		handle = std::to_string((unsigned long long)hwnd);
-	}
+        HWND hwnd = static_cast<HWND>(SDL_GetPointerProperty(SDL_GetWindowProperties(mMainVideoSurface), SDL_PROP_WINDOW_WIN32_HWND_POINTER, NULL));
+        if (hwnd) {
+                auto hwndValue = reinterpret_cast<std::uintptr_t>(hwnd);
+                handle = std::to_string(hwndValue);
+        }
 #else
-	auto xwindow = (unsigned long)SDL_GetNumberProperty(SDL_GetWindowProperties(mMainVideoSurface), SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0);
-	handle = std::to_string(xwindow);
+        auto xwindow = static_cast<std::uintptr_t>(SDL_GetNumberProperty(SDL_GetWindowProperties(mMainVideoSurface), SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0));
+        handle = std::to_string(xwindow);
 #endif
 
 


### PR DESCRIPTION
## Summary
- replace raw unsigned long casts when retrieving window handles with std::uintptr_t
- allow std::to_string to operate on uintptr_t
- include cstdint for portability

## Testing
- `g++ -std=c++17 -Iapps/ember/src -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include -c apps/ember/src/services/input/Input.cpp -o /tmp/Input.o` *(failed: SDL3/SDL_scancode.h: No such file or directory)*
- `g++ -m32 -std=c++17 -Iapps/ember/src -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include -c apps/ember/src/services/input/Input.cpp -o /tmp/Input_lin32.o` *(failed: SDL3/SDL_scancode.h: No such file or directory)*
- `x86_64-w64-mingw32-g++ -std=c++17 -Iapps/ember/src -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include -c apps/ember/src/services/input/Input.cpp -o /tmp/Input_win64.o` *(failed: boost/noncopyable.hpp: No such file or directory)*
- `i686-w64-mingw32-g++ -std=c++17 -Iapps/ember/src -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include -c apps/ember/src/services/input/Input.cpp -o /tmp/Input_win32.o` *(failed: boost/noncopyable.hpp: No such file or directory)*
- `clang++ -target x86_64-apple-darwin -std=c++17 -Iapps/ember/src -c apps/ember/src/services/input/Input.cpp -o /tmp/Input_mac64.o` *(failed: 'cassert' file not found)*
- `clang++ -target i386-apple-darwin -std=c++17 -Iapps/ember/src -c apps/ember/src/services/input/Input.cpp -o /tmp/Input_mac32.o` *(failed: 'cassert' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af528b59a4832d95d9c98f744b65f4