### PR TITLE
Add tests for nanite and performance tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,8 @@ endmacro()
 add_subdirectory(external)
 add_subdirectory(libs)
 add_subdirectory(apps)
+add_subdirectory(tools/nanite/tests)
+add_subdirectory(tools/performance/tests)
 
 # Packaging
 

--- a/tools/nanite/tests/CMakeLists.txt
+++ b/tools/nanite/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR})
+add_executable(MeshPreprocessorTest MeshPreprocessorTest.cpp)
+add_test(NAME MeshPreprocessorTest COMMAND MeshPreprocessorTest)

--- a/tools/nanite/tests/MeshPreprocessorTest.cpp
+++ b/tools/nanite/tests/MeshPreprocessorTest.cpp
@@ -1,0 +1,47 @@
+#include <cassert>
+#include <fstream>
+#include <vector>
+#include <cstdlib>
+
+#define main mesh_preprocessor_main
+#include "../MeshPreprocessor.cpp"
+#undef main
+
+int main() {
+    const char* objPath = "test.obj";
+    const char* outPath = "out.nanite";
+    {
+        std::ofstream obj(objPath);
+        obj << "v 0 0 0\n"
+            << "v 1 0 0\n"
+            << "v 1 1 0\n"
+            << "v 0 1 0\n"
+            << "f 1 2 3\n"
+            << "f 1 3 4\n";
+    }
+    char* argv[] = {(char*)"MeshPreprocessor", (char*)objPath, (char*)outPath};
+    int ret = mesh_preprocessor_main(3, argv);
+    assert(ret == 0);
+
+    std::ifstream in(outPath, std::ios::binary);
+    assert(in.good());
+    uint32_t clusterCount;
+    in.read(reinterpret_cast<char*>(&clusterCount), sizeof(clusterCount));
+    assert(clusterCount == 1);
+    Ogre::Vector3 min, max;
+    in.read(reinterpret_cast<char*>(&min), sizeof(min));
+    in.read(reinterpret_cast<char*>(&max), sizeof(max));
+    assert(min == Ogre::Vector3(0,0,0));
+    assert(max == Ogre::Vector3(1,1,0));
+    uint32_t icount;
+    in.read(reinterpret_cast<char*>(&icount), sizeof(icount));
+    assert(icount == 6);
+    std::vector<unsigned int> indices(icount);
+    in.read(reinterpret_cast<char*>(indices.data()), icount * sizeof(unsigned int));
+    std::vector<unsigned int> expected{0,1,2,0,2,3};
+    assert(indices == expected);
+    uint32_t childCount;
+    in.read(reinterpret_cast<char*>(&childCount), sizeof(childCount));
+    assert(childCount == 0);
+    return 0;
+}

--- a/tools/nanite/tests/include/OgreAxisAlignedBox.h
+++ b/tools/nanite/tests/include/OgreAxisAlignedBox.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <algorithm>
+#include "OgreVector3.h"
+namespace Ogre {
+class AxisAlignedBox {
+    Vector3 mMin, mMax;
+    bool mNull;
+public:
+    AxisAlignedBox() { setNull(); }
+    void setNull() { mMin = Vector3(); mMax = Vector3(); mNull = true; }
+    void merge(const Vector3& v) {
+        if (mNull) {
+            mMin = mMax = v;
+            mNull = false;
+        } else {
+            mMin.x = std::min(mMin.x, v.x);
+            mMin.y = std::min(mMin.y, v.y);
+            mMin.z = std::min(mMin.z, v.z);
+            mMax.x = std::max(mMax.x, v.x);
+            mMax.y = std::max(mMax.y, v.y);
+            mMax.z = std::max(mMax.z, v.z);
+        }
+    }
+    Vector3 getMinimum() const { return mMin; }
+    Vector3 getMaximum() const { return mMax; }
+};
+}

--- a/tools/nanite/tests/include/OgreVector3.h
+++ b/tools/nanite/tests/include/OgreVector3.h
@@ -1,0 +1,11 @@
+#pragma once
+namespace Ogre {
+struct Vector3 {
+    float x, y, z;
+    Vector3() : x(0), y(0), z(0) {}
+    Vector3(float X, float Y, float Z) : x(X), y(Y), z(Z) {}
+    bool operator==(const Vector3& other) const {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+}

--- a/tools/nanite/tests/include/apps/ember/src/components/ogre/lod/NaniteLodDefinition.h
+++ b/tools/nanite/tests/include/apps/ember/src/components/ogre/lod/NaniteLodDefinition.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "OgreAxisAlignedBox.h"
+
+namespace Ogre {
+class ResourceManager;
+using String = std::string;
+using ResourceHandle = unsigned long long;
+class ManualResourceLoader;
+}
+
+namespace Ember::OgreView::Lod {
+class LodDefinition {};
+class NaniteLodDefinition : public LodDefinition {
+public:
+    struct Cluster {
+        Ogre::AxisAlignedBox bounds;
+        std::vector<unsigned int> indices;
+        std::vector<size_t> children;
+        Cluster() { bounds.setNull(); }
+    };
+    NaniteLodDefinition(Ogre::ResourceManager*, const Ogre::String&, Ogre::ResourceHandle,
+                        const Ogre::String&, bool = false, Ogre::ManualResourceLoader* = nullptr) {}
+    void addCluster(Cluster cluster) { mClusters.push_back(std::move(cluster)); }
+    const std::vector<Cluster>& getClusters() const { return mClusters; }
+private:
+    std::vector<Cluster> mClusters;
+};
+}

--- a/tools/performance/tests/CMakeLists.txt
+++ b/tools/performance/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+include_directories(${CMAKE_SOURCE_DIR})
+add_executable(ProfilerCLI ../ProfilerCLI.cpp ../../../apps/ember/src/framework/Profiler.cpp)
+add_executable(ProfilerCLITest ProfilerCLITest.cpp ../../../apps/ember/src/framework/Profiler.cpp)
+add_dependencies(ProfilerCLITest ProfilerCLI)
+add_test(NAME ProfilerCLITest COMMAND ProfilerCLITest)

--- a/tools/performance/tests/ProfilerCLITest.cpp
+++ b/tools/performance/tests/ProfilerCLITest.cpp
@@ -1,0 +1,33 @@
+#include <cassert>
+#include <fstream>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <chrono>
+#include "../../../apps/ember/src/framework/Profiler.h"
+
+int main() {
+    using namespace Ember;
+    Profiler::start("terrainUpdate");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    Profiler::stop("terrainUpdate");
+
+    std::system("./ProfilerCLI > out1.txt");
+    {
+        std::ifstream in("out1.txt");
+        std::string label; double val;
+        in >> label >> val;
+        assert(label == "terrainUpdate_ms");
+        assert(val > 0.0);
+    }
+
+    std::system("./ProfilerCLI extra > out2.txt");
+    {
+        std::ifstream in("out2.txt");
+        std::string label; double val;
+        in >> label >> val;
+        assert(label == "terrainUpdate_ms");
+        assert(val > 0.0);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add MeshPreprocessor test with stubbed Ogre dependencies
- add ProfilerCLI test covering CLI output
- enable tools tests in top-level CMake

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread))*


------
https://chatgpt.com/codex/tasks/task_e_68b0d26be088832da9f00a593f6b23c7