### PR TITLE
feat: migrate varconf tests to catch2

### DIFF
--- a/libs/varconf/tests/CMakeLists.txt
+++ b/libs/varconf/tests/CMakeLists.txt
@@ -1,2 +1,6 @@
+find_package(Catch2 3 REQUIRED)
+
 wf_add_test(conftest.cpp)
 add_compile_definitions(SRCDIR="${PROJECT_SOURCE_DIR}/tests")
+
+target_link_libraries(conftest PRIVATE Catch2::Catch2WithMain)

--- a/libs/varconf/tests/conftest.cpp
+++ b/libs/varconf/tests/conftest.cpp
@@ -4,13 +4,13 @@
 
 #include <sigc++/slot.h>
 
+#include <catch2/catch_test_macros.hpp>
+
 #include <iostream>
 #include <string>
 #include <sstream>
 #include <filesystem>
 #include <chrono>
-
-#include <cassert>
 
 struct TempDir {
         std::filesystem::path path;
@@ -30,102 +30,108 @@ void callback(const std::string& section,
 }
 
 void error(const char* message) {
-	std::cerr << message;
+        std::cerr << message;
 }
 
-int main(int argc, char** argv) {
-	varconf::Config config;
+TEST_CASE("Varconf configuration operations", "[varconf]") {
+        varconf::Config config;
 
-	config.sige.connect(sigc::ptr_fun(error));
-	config.sigsv.connect(sigc::ptr_fun(callback));
+        config.sige.connect(sigc::ptr_fun(error));
+        config.sigsv.connect(sigc::ptr_fun(callback));
 
-	config.setParameterLookup('f', "foo", true);
-	config.setParameterLookup('b', "bar", false);
+        config.setParameterLookup('f', "foo", true);
+        config.setParameterLookup('b', "bar", false);
 
-	config.getCmdline(argc, argv);
-	config.getEnv("TEST_");
-	assert(config.readFromFile(std::string(SRCDIR) + "/conf.cfg"));
-	config.setItem("tcp", "port", 6700, varconf::GLOBAL);
-	config.setItem("tcp", "v6port", 6700, varconf::USER);
-	config.setItem("console", "colours", "plenty", varconf::INSTANCE);
-	config.setItem("console", "speed", "fast", varconf::USER);
+        config.getCmdline(0, nullptr);
+        config.getEnv("TEST_");
+        REQUIRE(config.readFromFile(std::string(SRCDIR) + "/conf.cfg"));
+        config.setItem("tcp", "port", 6700, varconf::GLOBAL);
+        config.setItem("tcp", "v6port", 6700, varconf::USER);
+        config.setItem("console", "colours", "plenty", varconf::INSTANCE);
+        config.setItem("console", "speed", "fast", varconf::USER);
 
-	assert(config.find("tcp", "port"));
-	assert(config.find("console", "enabled"));
-	assert(config.getItem("tcp", "port")->scope() == varconf::GLOBAL);
-	//Default scope for read files are USER
-	assert(config.getItem("console", "enabled")->scope() == varconf::USER);
-
-	std::cout << "\nEnter sample configuration data to test parseStream() method.\n";
-
-	std::stringstream ss;
-	ss << "[general]" << std::endl;
-	ss << "setting = true" << std::endl;
-	ss << "emptyrightbeforeeof = ";
-
-	try {
-		config.parseStream(ss, varconf::USER);
-	}
-	catch (const varconf::ParseError& p) {
-		std::cout << "\nError while parsing from input stream.\n";
-		std::cout << p.what();
-	}
-
-        assert(config.find("general", "setting"));
-        assert(config.find("general", "emptyrightbeforeeof"));
-
-        std::filesystem::path conf_file;
-        {
-                TempDir tmp;
-                conf_file = tmp.path / "conf2.cfg";
-                config.writeToFile(conf_file.string());
-                assert(std::filesystem::exists(conf_file));
-
-                varconf::Config file_conf;
-                assert(file_conf.readFromFile(conf_file.string()));
-                assert(file_conf.find("general", "setting"));
-                assert(file_conf.find("general", "emptyrightbeforeeof"));
+        SECTION("Lookup loaded items") {
+                REQUIRE(config.find("tcp", "port"));
+                REQUIRE(config.find("console", "enabled"));
+                REQUIRE(config.getItem("tcp", "port")->scope() == varconf::GLOBAL);
+                // Default scope for read files are USER
+                REQUIRE(config.getItem("console", "enabled")->scope() == varconf::USER);
         }
-        assert(!std::filesystem::exists(conf_file));
 
-        std::cout << "\nFile configuration data:\n"
-                          << "--------------------------\n"
-                          << config;
+        SECTION("Parse configuration stream") {
+                std::cout << "\nEnter sample configuration data to test parseStream() method.\n";
 
-	std::cout << "\nUSER configuration data:\n"
-			  << "--------------------------\n";
+                std::stringstream ss;
+                ss << "[general]" << std::endl;
+                ss << "setting = true" << std::endl;
+                ss << "emptyrightbeforeeof = ";
 
-	config.writeToStream(std::cout, varconf::USER);
+                try {
+                        config.parseStream(ss, varconf::USER);
+                }
+                catch (const varconf::ParseError& p) {
+                        std::cout << "\nError while parsing from input stream.\n";
+                        std::cout << p.what();
+                }
 
-	std::cout << "\nINSTANCE configuration data:\n"
-			  << "--------------------------\n";
+                REQUIRE(config.find("general", "setting"));
+                REQUIRE(config.find("general", "emptyrightbeforeeof"));
+        }
 
-	config.writeToStream(std::cout, varconf::INSTANCE);
+        SECTION("Write configuration to file and read back") {
+                std::filesystem::path conf_file;
+                {
+                        TempDir tmp;
+                        conf_file = tmp.path / "conf2.cfg";
+                        config.writeToFile(conf_file.string());
+                        REQUIRE(std::filesystem::exists(conf_file));
 
-	std::cout << "\nGLOBAL configuration data:\n"
-			  << "--------------------------\n";
+                        varconf::Config file_conf;
+                        REQUIRE(file_conf.readFromFile(conf_file.string()));
+                        REQUIRE(file_conf.find("general", "setting"));
+                        REQUIRE(file_conf.find("general", "emptyrightbeforeeof"));
+                }
+                REQUIRE(!std::filesystem::exists(conf_file));
+        }
 
-	config.writeToStream(std::cout, varconf::GLOBAL);
+        SECTION("Output configuration data") {
+                std::cout << "\nFile configuration data:\n"
+                                  << "--------------------------\n"
+                                  << config;
 
-	std::cout << "\nGLOBAL & USER configuration data:\n"
-			  << "--------------------------\n";
+                std::cout << "\nUSER configuration data:\n"
+                                  << "--------------------------\n";
 
-	config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::USER));
+                config.writeToStream(std::cout, varconf::USER);
 
-	std::cout << "\nINSTANCE & USER configuration data:\n"
-			  << "--------------------------\n";
+                std::cout << "\nINSTANCE configuration data:\n"
+                                  << "--------------------------\n";
 
-	config.writeToStream(std::cout, (varconf::Scope) (varconf::INSTANCE | varconf::USER));
+                config.writeToStream(std::cout, varconf::INSTANCE);
 
-	std::cout << "\nINSTANCE & GLOBAL configuration data:\n"
-			  << "--------------------------\n";
+                std::cout << "\nGLOBAL configuration data:\n"
+                                  << "--------------------------\n";
 
-	config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::INSTANCE));
+                config.writeToStream(std::cout, varconf::GLOBAL);
 
-	std::cout << "\nINSTANCE, USER & GLOBAL configuration data:\n"
-			  << "--------------------------\n";
+                std::cout << "\nGLOBAL & USER configuration data:\n"
+                                  << "--------------------------\n";
 
-	config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::INSTANCE | varconf::USER));
+                config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::USER));
 
-	return 0;
+                std::cout << "\nINSTANCE & USER configuration data:\n"
+                                  << "--------------------------\n";
+
+                config.writeToStream(std::cout, (varconf::Scope) (varconf::INSTANCE | varconf::USER));
+
+                std::cout << "\nINSTANCE & GLOBAL configuration data:\n"
+                                  << "--------------------------\n";
+
+                config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::INSTANCE));
+
+                std::cout << "\nINSTANCE, USER & GLOBAL configuration data:\n"
+                                  << "--------------------------\n";
+
+                config.writeToStream(std::cout, (varconf::Scope) (varconf::GLOBAL | varconf::INSTANCE | varconf::USER));
+        }
 }


### PR DESCRIPTION
## Summary
- migrate varconf test to Catch2 framework, replacing manual main and asserts
- integrate Catch2 in varconf CMake to run under CTest

## Testing
- `ctest --preset conan-release` (fails: CMakePresets.json not found)


------
https://chatgpt.com/codex/tasks/task_e_68b3088385cc832d96c5f069f0e2c42d