### PR TITLE
Replace SRCDIR macros with runtime path resolution

### DIFF
--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -59,7 +59,8 @@ if (TARGET cppunit::cppunit)
             TestFramework.cpp
             $<TARGET_OBJECTS:ember-framework>
             $<TARGET_OBJECTS:ember-tinyxml>)
-    target_compile_definitions(TestFramework PUBLIC -DLOG_TASKS -DSRCDIR="${CMAKE_CURRENT_SOURCE_DIR}")
+    target_compile_definitions(TestFramework PUBLIC -DLOG_TASKS)
+    configure_file(atlas.xml atlas.xml COPYONLY)
     target_link_libraries(TestFramework
             cppunit::cppunit
             mojoal

--- a/apps/ember/tests/TestFramework.cpp
+++ b/apps/ember/tests/TestFramework.cpp
@@ -16,8 +16,10 @@
 
 #include <boost/date_time.hpp>
 #include <Atlas/Objects/Factories.h>
+#include <filesystem>
 
 Atlas::Objects::Factories factories;
+static std::filesystem::path g_dataPath;
 
 namespace Ember {
 
@@ -30,7 +32,7 @@ class FrameworkTestCase : public CppUnit::TestFixture {
 public:
 	void testTinyXmlCodec() {
 		TiXmlDocument xmlDoc;
-		bool result = xmlDoc.LoadFile(std::string(SRCDIR) + "/atlas.xml", TIXML_DEFAULT_ENCODING);
+                bool result = xmlDoc.LoadFile((g_dataPath / "atlas.xml").string().c_str(), TIXML_DEFAULT_ENCODING);
 		CPPUNIT_ASSERT(result);
 
 		std::map <std::string, Atlas::Objects::Root> messages;
@@ -76,7 +78,8 @@ public:
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::FrameworkTestCase);
 
 int main(int argc, char** argv) {
-	CppUnit::TextUi::TestRunner runner;
+        g_dataPath = std::filesystem::absolute(argv[0]).parent_path();
+        CppUnit::TextUi::TestRunner runner;
 	CppUnit::TestFactoryRegistry& registry = CppUnit::TestFactoryRegistry::getRegistry();
 	runner.addTest(registry.makeTest());
 

--- a/libs/varconf/tests/CMakeLists.txt
+++ b/libs/varconf/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 wf_add_test(conftest.cpp)
-add_compile_definitions(SRCDIR="${PROJECT_SOURCE_DIR}/tests")
+configure_file(conf.cfg conf.cfg COPYONLY)

--- a/libs/varconf/tests/conftest.cpp
+++ b/libs/varconf/tests/conftest.cpp
@@ -42,9 +42,10 @@ int main(int argc, char** argv) {
 	config.setParameterLookup('f', "foo", true);
 	config.setParameterLookup('b', "bar", false);
 
-	config.getCmdline(argc, argv);
-	config.getEnv("TEST_");
-	assert(config.readFromFile(std::string(SRCDIR) + "/conf.cfg"));
+        config.getCmdline(argc, argv);
+        config.getEnv("TEST_");
+        std::filesystem::path exePath = std::filesystem::absolute(argv[0]).parent_path();
+        assert(config.readFromFile((exePath / "conf.cfg").string()));
 	config.setItem("tcp", "port", 6700, varconf::GLOBAL);
 	config.setItem("tcp", "v6port", 6700, varconf::USER);
 	config.setItem("console", "colours", "plenty", varconf::INSTANCE);


### PR DESCRIPTION
## Summary
- resolve test fixture paths at runtime instead of using `SRCDIR`
- copy configuration and XML fixtures into test build directories via CMake
- adjust tests to consume these runtime paths

## Testing
- `cmake -S libs/varconf -B build_varconf` *(fails: Could not find a package configuration file provided by "sigc++-3")*
- `cmake -S apps/ember -B build_ember` *(fails: Unknown CMake command "wf_find_boost")*


------
https://chatgpt.com/codex/tasks/task_e_68b3088c4198832d9d3153af2c69aa6c