### PR TITLE
Add prebuilt artifact verification and release publishing

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -130,12 +130,52 @@ jobs:
                 shell: bash
                 run: ctest --preset conan-release --output-on-failure
 
+            -   name: Verify prebuilt binaries
+                shell: bash
+                run: |
+                    set -e
+                    ls -R "${{ github.workspace }}/prebuilt"
+                    for bin in cyphesis ember; do
+                        if [ ! -x "${{ github.workspace }}/prebuilt/bin/$bin" ]; then
+                            echo "Missing required binary: $bin"
+                            exit 1
+                        fi
+                    done
+
+            -   name: Generate checksum manifest
+                shell: bash
+                run: |
+                    find "${{ github.workspace }}/prebuilt" -type f -exec sha256sum {} + | sort > "${{ github.workspace }}/prebuilt/manifest.sha256"
+
+            -   name: Create prebuilt archive
+                if: github.ref == 'refs/heads/master'
+                shell: bash
+                run: |
+                    tar -czf "${{ github.workspace }}/prebuilt.tar.gz" -C "${{ github.workspace }}/prebuilt" .
+
             -   name: Upload prebuilt
                 uses: actions/upload-artifact@v4.6.1
                 with:
                     name: prebuilt
                     path: ${{ github.workspace }}/prebuilt
                     retention-days: 30
+
+            -   name: Upload manifest
+                uses: actions/upload-artifact@v4.6.1
+                with:
+                    name: prebuilt-manifest
+                    path: ${{ github.workspace }}/prebuilt/manifest.sha256
+                    retention-days: 30
+
+            -   name: Publish prebuilt release
+                if: github.ref == 'refs/heads/master' && success()
+                uses: softprops/action-gh-release@v2
+                with:
+                    tag_name: prebuilt-${{ github.run_number }}
+                    name: Prebuilt ${{ github.run_number }}
+                    files: |
+                        ${{ github.workspace }}/prebuilt.tar.gz
+                        ${{ github.workspace }}/prebuilt/manifest.sha256
 
     package:
         name: Package on *NIX and Windows

--- a/README.md
+++ b/README.md
@@ -68,11 +68,21 @@ If you only want to build the server or the client you can supply these options 
 
 ### Prebuilt CI artifacts
 
-Our continuous integration builds precompiled binaries and packages them as
-`prebuilt/` artifacts. You can download these from the
+Our continuous integration builds precompiled binaries in the `prebuilt/` directory.
+For each successful run you can download these from the
 [build-all workflow](https://github.com/worldforge/worldforge/actions/workflows/build-all.yml)
-on GitHub Actions. Select a successful run and expand **Artifacts** to find
-the `prebuilt` archive.
+on GitHub Actions. Select a successful run and expand **Artifacts** to find the
+`prebuilt` archive and its `prebuilt-manifest` checksum file.
+
+Runs on the `master` branch also publish a `prebuilt.tar.gz` and accompanying
+`manifest.sha256` file on the [Releases](https://github.com/worldforge/worldforge/releases) page.
+Verify downloads with:
+
+```bash
+sha256sum -c manifest.sha256
+tar -xzf prebuilt.tar.gz
+./prebuilt/bin/cyphesis --help
+```
 
 Artifacts are published only for workflow runs where all tests pass.
 


### PR DESCRIPTION
## Summary
- verify required binaries and create checksum manifest for prebuilt artifacts
- publish prebuilt artifacts and manifest to GitHub release on master builds
- document how to retrieve and verify prebuilt artifacts

## Testing
- `cmake --build --preset conan-release --target check` *(fails: File not found: /workspace/worldforge/CMakePresets.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3088cc374832d86253b3c9f4b94b4