### PR TITLE
Handle missing /say command and validate console entries

### DIFF
--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -68,6 +68,17 @@ if (TARGET cppunit::cppunit)
     add_test(NAME TestFramework COMMAND TestFramework)
     add_dependencies(check TestFramework)
 
+    add_executable(TestConsoleBackend
+            TestConsoleBackend.cpp
+            $<TARGET_OBJECTS:ember-framework>
+            $<TARGET_OBJECTS:ember-tinyxml>)
+    target_compile_definitions(TestConsoleBackend PUBLIC -DLOG_TASKS)
+    target_link_libraries(TestConsoleBackend
+            cppunit::cppunit
+            mojoal)
+    add_test(NAME TestConsoleBackend COMMAND TestConsoleBackend)
+    add_dependencies(check TestConsoleBackend)
+
     #    add_executable(TestTerrain TestTerrain.cpp)
     #    target_compile_definitions(TestTerrain PUBLIC -DLOG_TASKS)
     #    target_link_libraries(TestTerrain ${CPPUNIT_LIBRARIES} ${WF_LIBRARIES} emberogre terrain caelum pagedgeometry entitymapping lua services framework)

--- a/apps/ember/tests/TestConsoleBackend.cpp
+++ b/apps/ember/tests/TestConsoleBackend.cpp
@@ -1,0 +1,55 @@
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/TestResult.h>
+
+#include "framework/ConsoleBackend.h"
+
+#include <algorithm>
+
+namespace Ember {
+
+class ConsoleBackendTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(ConsoleBackendTestCase);
+        CPPUNIT_TEST(testSpeechFallback);
+        CPPUNIT_TEST(testInvalidCommandEntry);
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void testSpeechFallback() {
+                ConsoleBackend backend;
+                backend.runCommand("hello world");
+                const auto& messages = backend.getConsoleMessages();
+                CPPUNIT_ASSERT(!messages.empty());
+                CPPUNIT_ASSERT(messages.back() == "Cannot send speech: '/say' command not available.");
+        }
+
+        void testInvalidCommandEntry() {
+                ConsoleBackend backend;
+                ConsoleBackend::ConsoleCallback callback;
+                backend.registerCommand("badcmd", callback, "bad command");
+                backend.runCommand("/list_commands");
+                const auto& messages = backend.getConsoleMessages();
+                auto it = std::find_if(messages.begin(), messages.end(), [](const std::string& msg) {
+                        return msg.find("Invalid command entry: badcmd") != std::string::npos;
+                });
+                CPPUNIT_ASSERT(it != messages.end());
+        }
+};
+
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(Ember::ConsoleBackendTestCase);
+
+int main(int argc, char** argv) {
+        CppUnit::TextUi::TestRunner runner;
+        CppUnit::TestFactoryRegistry& registry = CppUnit::TestFactoryRegistry::getRegistry();
+        runner.addTest(registry.makeTest());
+
+        CppUnit::BriefTestProgressListener listener;
+        runner.eventManager().addListener(&listener);
+
+        bool wasSuccessful = runner.run("", false);
+        return !wasSuccessful;
+}


### PR DESCRIPTION
## Summary
- Warn users when speech is attempted but `/say` command isn't registered
- Guard against invalid console command entries when listing commands
- Add unit tests for speech fallback and invalid command entries

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "Microsoft.GSL")*

------
https://chatgpt.com/codex/tasks/task_e_68b31106a7f0832db5185de31faabcee