### PR TITLE
Handle Bzip2 errors and add failure tests

### DIFF
--- a/libs/atlas/CMakeLists.txt
+++ b/libs/atlas/CMakeLists.txt
@@ -135,6 +135,7 @@ endmacro()
 
 wf_add_test(tests/Message/ElementTest.cpp)
 wf_add_test(tests/Codecs/codecs.cpp)
+wf_add_test(tests/Filters/bzip2.cpp)
 wf_add_test(tests/Objects/custom_ops.cpp)
 wf_add_test(tests/Objects/objects1.cpp tests/Objects/loadDefaults.cpp)
 wf_add_test(tests/Objects/objects2.cpp tests/Objects/DebugBridge.h tests/Objects/loadDefaults.cpp)

--- a/libs/atlas/tests/Filters/bzip2.cpp
+++ b/libs/atlas/tests/Filters/bzip2.cpp
@@ -1,0 +1,42 @@
+#if defined(HAVE_BZLIB_H) && defined(HAVE_LIBBZ2)
+#include <Atlas/Filters/Bzip2.h>
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+using Atlas::Filters::Bzip2;
+
+void testDecodeMalformed() {
+    Bzip2 filter;
+    filter.begin();
+    bool threw = false;
+    try {
+        filter.decode("not a bzip2 stream");
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    filter.end();
+    assert(threw);
+}
+
+void testEncodeAfterEnd() {
+    Bzip2 filter;
+    filter.begin();
+    filter.end();
+    bool threw = false;
+    try {
+        filter.encode(std::string(50000, 'x'));
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+int main() {
+    testDecodeMalformed();
+    testEncodeAfterEnd();
+    return 0;
+}
+#else
+int main() { return 0; }
+#endif


### PR DESCRIPTION
## Summary
- throw `std::runtime_error` when BZ2 compression or decompression fails
- add unit tests covering malformed and post-end oversized inputs

## Testing
- `g++ -std=c++20 libs/atlas/tests/Filters/bzip2.cpp libs/atlas/src/Atlas/Filters/Bzip2.cpp libs/atlas/src/Atlas/Filter.cpp -Ilibs/atlas/src -DHAVE_BZLIB_H -DHAVE_LIBBZ2 -lbz2 -o /tmp/bzip2_test`
- `/tmp/bzip2_test`
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread))*


------
https://chatgpt.com/codex/tasks/task_e_68b311097dcc832d955ed13df30a0b92