### PR TITLE
Enable Ember tests and run in CI

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -128,7 +128,7 @@ jobs:
 
             -   name: Test
                 shell: bash
-                run: ctest --preset conan-release --output-on-failure
+                run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build --preset conan-release --target check
 
             -   name: Verify prebuilt binaries
                 shell: bash

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -93,7 +93,7 @@ jobs:
 
             -   name: Test
                 shell: bash
-                run: ctest --preset $PROFILE_CONAN --output-on-failure
+                run: CTEST_OUTPUT_ON_FAILURE=1 cmake --build --preset $PROFILE_CONAN --target check
 
             -   name: End-to-end client session
                 shell: bash

--- a/apps/ember/CMakeLists.txt
+++ b/apps/ember/CMakeLists.txt
@@ -121,8 +121,7 @@ endif ()
 
 add_subdirectory(external)
 add_subdirectory(src)
-#TODO: enable again once we've sorted the monorepo
-#add_subdirectory(tests)
+add_subdirectory(tests)
 
 file(GLOB MODELDEFINITIONS_FILES data/dural/*.modeldef)
 foreach (FILE ${MODELDEFINITIONS_FILES})


### PR DESCRIPTION
## Summary
- Re-enable Ember test compilation by restoring tests subdirectory
- Ensure GitHub workflows build the `check` target so Ember tests run

## Testing
- `conan install . -pr default --build=missing --lockfile-partial` *(fails: Package 'ogre-next/2.3.0@worldforge' not resolved)*
- `cmake -S . -B build -DBUILD_TESTING=ON -DATLAS_GENERATE_OBJECTS=OFF -DATLAS_DISABLE_BENCHMARKS=ON` *(fails: could not find package spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_68b31116974c832dabb5cb2bfaa147fb