### PR TITLE
refactor: inject ember services

### DIFF
--- a/apps/ember/src/main/Application.cpp
+++ b/apps/ember/src/main/Application.cpp
@@ -18,6 +18,7 @@
 #include "services/metaserver/MetaserverService.h"
 #include "services/sound/SoundService.h"
 #include "services/scripting/ScriptingService.h"
+#include "services/serversettings/ServerSettings.h"
 #include "services/input/Input.h"
 
 #include "framework/ShutdownException.h"
@@ -438,7 +439,17 @@ void Application::initializeServices() {
 	// Initialize Ember services
 	logger->info("Initializing Ember services");
 
-	mServices = std::make_unique<EmberServices>(*mSession, mConfigService);
+        auto scriptingService = std::make_unique<ScriptingService>();
+        auto soundService = std::make_unique<SoundService>(mConfigService);
+        auto serverService = std::make_unique<ServerService>(*mSession);
+        auto metaserverService = std::make_unique<MetaserverService>(*mSession, mConfigService);
+        auto serverSettingsService = std::make_unique<ServerSettings>();
+        mServices = std::make_unique<EmberServices>(mConfigService,
+                                                   std::move(scriptingService),
+                                                   std::move(soundService),
+                                                   std::move(serverService),
+                                                   std::move(metaserverService),
+                                                   std::move(serverSettingsService));
 
 	mInput.setMainLoopController(&mMainLoopController);
 

--- a/apps/ember/src/services/EmberServices.cpp
+++ b/apps/ember/src/services/EmberServices.cpp
@@ -24,19 +24,24 @@
 #include "server/ServerService.h"
 #include "scripting/ScriptingService.h"
 #include "serversettings/ServerSettings.h"
+#include <utility>
 
 namespace Ember {
 
 
-EmberServices::~EmberServices() = default;
+EmberServices::EmberServices(ConfigService& inConfigService,
+                             std::unique_ptr<ScriptingService> inScriptingService,
+                             std::unique_ptr<SoundService> inSoundService,
+                             std::unique_ptr<ServerService> inServerService,
+                             std::unique_ptr<MetaserverService> inMetaserverService,
+                             std::unique_ptr<ServerSettings> inServerSettingsService)
+        : configService(inConfigService),
+          scriptingService(std::move(inScriptingService)),
+          soundService(std::move(inSoundService)),
+          serverService(std::move(inServerService)),
+          metaserverService(std::move(inMetaserverService)),
+          serverSettingsService(std::move(inServerSettingsService)) {}
 
-EmberServices::EmberServices(Session& session, ConfigService& inConfigService)
-		: configService(inConfigService),
-		  scriptingService(std::make_unique<ScriptingService>()),
-		  soundService(std::make_unique<SoundService>(configService)),
-		  serverService(std::make_unique<ServerService>(session)),
-		  metaserverService(std::make_unique<MetaserverService>(session, configService)),
-		  serverSettingsService(std::make_unique<ServerSettings>()) {
-}
+EmberServices::~EmberServices() = default;
 
 }

--- a/apps/ember/src/services/EmberServices.h
+++ b/apps/ember/src/services/EmberServices.h
@@ -23,7 +23,6 @@
 #include <memory>
 
 namespace Ember {
-struct Session;
 
 // some forward declarations before we start
 class ConfigService;
@@ -40,38 +39,39 @@ class ServerSettings;
 
 
 /**
- * This is a singleton class that is used to access instances of all the
- * different Ember services.
+ * Aggregates instances of the various Ember services.
  *
- * There's a getServiceName() method for each service. <p>
+ * Service instances are supplied externally, allowing for dependency injection
+ * and improved testability.
  *
- * TODO: Should this class also create the instances of the services,
- * or should it have set methods for them?  <p>
- *
- * Example: <p>
- * <code>
- *
- *   EmberServices.getInstance()->getLoggingService()->log( ... );  <br/>
- *   ... = EmberServices.getInstance()->getMetaServerService()->getMetaServerList();
- *
- * </code>
- *
- * @author Hans Häggström
+ * Example usage:
+ * @code
+ *   auto services = EmberServices(config,
+ *                                 std::make_unique<ScriptingService>(),
+ *                                 std::make_unique<SoundService>(config),
+ *                                 std::make_unique<ServerService>(session),
+ *                                 std::make_unique<MetaserverService>(session, config),
+ *                                 std::make_unique<ServerSettings>());
+ * @endcode
  */
 struct EmberServices {
 
+        EmberServices(ConfigService& configService,
+                     std::unique_ptr<ScriptingService> scriptingService,
+                     std::unique_ptr<SoundService> soundService,
+                     std::unique_ptr<ServerService> serverService,
+                     std::unique_ptr<MetaserverService> metaserverService,
+                     std::unique_ptr<ServerSettings> serverSettingsService);
 
-	explicit EmberServices(Session& session, ConfigService& configService);
+        ~EmberServices();
 
-	~EmberServices();
+        ConfigService& configService;
 
-	ConfigService& configService;
-
-	std::unique_ptr<ScriptingService> scriptingService;
-	std::unique_ptr<SoundService> soundService;
-	std::unique_ptr<ServerService> serverService;
-	std::unique_ptr<MetaserverService> metaserverService;
-	std::unique_ptr<ServerSettings> serverSettingsService;
+        std::unique_ptr<ScriptingService> scriptingService;
+        std::unique_ptr<SoundService> soundService;
+        std::unique_ptr<ServerService> serverService;
+        std::unique_ptr<MetaserverService> metaserverService;
+        std::unique_ptr<ServerSettings> serverSettingsService;
 
 };
 }

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -79,6 +79,16 @@ if (TARGET cppunit::cppunit)
     add_test(NAME TestConsoleBackend COMMAND TestConsoleBackend)
     add_dependencies(check TestConsoleBackend)
 
+    add_executable(TestEmberServices
+            TestEmberServices.cpp)
+    target_compile_definitions(TestEmberServices PUBLIC -DLOG_TASKS)
+    target_link_libraries(TestEmberServices
+            cppunit::cppunit
+            ember-services
+            mojoal)
+    add_test(NAME TestEmberServices COMMAND TestEmberServices)
+    add_dependencies(check TestEmberServices)
+
     #    add_executable(TestTerrain TestTerrain.cpp)
     #    target_compile_definitions(TestTerrain PUBLIC -DLOG_TASKS)
     #    target_link_libraries(TestTerrain ${CPPUNIT_LIBRARIES} ${WF_LIBRARIES} emberogre terrain caelum pagedgeometry entitymapping lua services framework)

--- a/apps/ember/tests/TestEmberServices.cpp
+++ b/apps/ember/tests/TestEmberServices.cpp
@@ -1,0 +1,61 @@
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/TestResult.h>
+
+#include "services/EmberServices.h"
+#include "services/scripting/ScriptingService.h"
+#include "services/config/ConfigService.h"
+
+#include <filesystem>
+
+namespace Ember {
+
+struct TrackingScriptingService : ScriptingService {
+        static bool destroyed;
+        ~TrackingScriptingService() override { destroyed = true; }
+};
+
+bool TrackingScriptingService::destroyed = false;
+
+class EmberServicesTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(EmberServicesTestCase);
+        CPPUNIT_TEST(testConstructionAndTeardown);
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void testConstructionAndTeardown() {
+                TrackingScriptingService::destroyed = false;
+                ConfigService config(std::filesystem::current_path());
+                {
+                        auto scripting = std::make_unique<TrackingScriptingService>();
+                        TrackingScriptingService* ptr = scripting.get();
+                        EmberServices services(config,
+                                                std::move(scripting),
+                                                std::unique_ptr<SoundService>(),
+                                                std::unique_ptr<ServerService>(),
+                                                std::unique_ptr<MetaserverService>(),
+                                                std::unique_ptr<ServerSettings>());
+                        CPPUNIT_ASSERT(services.scriptingService.get() == ptr);
+                        CPPUNIT_ASSERT(!TrackingScriptingService::destroyed);
+                }
+                CPPUNIT_ASSERT(TrackingScriptingService::destroyed);
+        }
+};
+
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(Ember::EmberServicesTestCase);
+
+int main(int argc, char** argv) {
+        CppUnit::TextUi::TestRunner runner;
+        CppUnit::TestFactoryRegistry& registry = CppUnit::TestFactoryRegistry::getRegistry();
+        runner.addTest(registry.makeTest());
+
+        CppUnit::BriefTestProgressListener listener;
+        runner.eventManager().addListener(&listener);
+
+        bool wasSuccessful = runner.run("", false);
+        return !wasSuccessful;
+}


### PR DESCRIPTION
## Summary
- adopt dependency injection for `EmberServices`
- inject service instances from `Application`
- add unit test verifying service registration and destruction

## Testing
- `cmake -S . -B build` *(fails: Could not find 'cegui/0.8.7@worldforge' in remotes)*

------
https://chatgpt.com/codex/tasks/task_e_68b3309dc61c832db2219c2abea364de