### PR TITLE
refactor: decouple server settings from singletons

### DIFF
--- a/apps/ember/src/components/ogre/widgets/ActionBarIconManager.cpp
+++ b/apps/ember/src/components/ogre/widgets/ActionBarIconManager.cpp
@@ -36,9 +36,10 @@
 namespace Ember::OgreView::Gui {
 
 ActionBarIconManager::ActionBarIconManager(GUIManager& guiManager)
-		: mGuiManager(guiManager),
-		  mIconsCounter(0),
-		  mSlotsCounter(0) {
+                : mGuiManager(guiManager),
+                  mIconsCounter(0),
+                  mSlotsCounter(0),
+                  mServerSettings() {
 }
 
 ActionBarIconManager::~ActionBarIconManager() = default;
@@ -91,13 +92,12 @@ std::string ActionBarIconManager::getSavedValue(const AvatarIdType& avatarId, co
 	std::string accountIdKey = avatarId.avatarId;
 	accountIdKey.append(key);
 
-	ServerSettingsCredentials serverCredentials(sInfo);
-	auto& serverSettings = ServerSettings::getSingleton();
+        ServerSettingsCredentials serverCredentials(sInfo);
 
-	if (serverSettings.findItem(serverCredentials, accountIdKey)) {
-		return static_cast<std::string>(serverSettings.getItem(serverCredentials, accountIdKey));
-	}
-	return "null";
+        if (mServerSettings.findItem(serverCredentials, accountIdKey)) {
+                return static_cast<std::string>(mServerSettings.getItem(serverCredentials, accountIdKey));
+        }
+        return "null";
 }
 
 void ActionBarIconManager::saveValue(const AvatarIdType& avatarId, const std::string& key, const std::string& value) {
@@ -105,11 +105,10 @@ void ActionBarIconManager::saveValue(const AvatarIdType& avatarId, const std::st
 	std::string accountIdKey = avatarId.avatarId;
 	accountIdKey.append(key);
 
-	ServerSettingsCredentials serverCredentials(sInfo);
-	auto& serverSettings = ServerSettings::getSingleton();
+        ServerSettingsCredentials serverCredentials(sInfo);
 
-	serverSettings.setItem(serverCredentials, accountIdKey, value);
-	serverSettings.writeToDisk();
+        mServerSettings.setItem(serverCredentials, accountIdKey, value);
+        mServerSettings.writeToDisk();
 }
 
 void ActionBarIconManager::eraseValue(const AvatarIdType& avatarId, const std::string& key) {
@@ -117,12 +116,11 @@ void ActionBarIconManager::eraseValue(const AvatarIdType& avatarId, const std::s
 	std::string accountIdKey = avatarId.avatarId;
 	accountIdKey.append(key);
 
-	ServerSettingsCredentials serverCredentials(sInfo);
-	auto& serverSettings = ServerSettings::getSingleton();
+        ServerSettingsCredentials serverCredentials(sInfo);
 
-	if (serverSettings.findItem(serverCredentials, accountIdKey)) {
-		serverSettings.eraseItem(serverCredentials, accountIdKey);
-	}
+        if (mServerSettings.findItem(serverCredentials, accountIdKey)) {
+                mServerSettings.eraseItem(serverCredentials, accountIdKey);
+        }
 }
 
 void ActionBarIconManager::destroyIcon(ActionBarIcon* icon) {

--- a/apps/ember/src/components/ogre/widgets/ActionBarIconManager.h
+++ b/apps/ember/src/components/ogre/widgets/ActionBarIconManager.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include "services/serversettings/ServerSettings.h"
 
 namespace Ember {
 class EmberEntity;
@@ -169,7 +170,12 @@ protected:
 	/**
 	 * @brief A counter used for providing unique names for each slot window.
 	 */
-	int mSlotsCounter;
+        int mSlotsCounter;
+
+        /**
+         * @brief Local server settings instance used for persistence.
+         */
+        ServerSettings mServerSettings;
 };
 
 }

--- a/apps/ember/src/components/ogre/widgets/ServerBrowser.lua
+++ b/apps/ember/src/components/ogre/widgets/ServerBrowser.lua
@@ -298,7 +298,7 @@ function ServerBrowser:getSavedAccount(sInfo)
 	-- Essentially we try and fetch the 'hostname_<host>_servername_<server>' section
 	-- get the 'username' key.  If this has a value, there is saved credentials
 	-- We are always expecting a string ... even if it's empty.
-	local serverService = Ember.ServerSettings.getSingleton()
+        local serverService = Ember.ServerSettings.new()
 	local serverSettingCredentials = Ember.ServerSettingsCredentials.new(sInfo.host, sInfo.name)
 	local savedUser = serverService:getItem(serverSettingCredentials, "username")
 	local retFav = savedUser:as_string()

--- a/apps/ember/src/components/ogre/widgets/ServerWidget.cpp
+++ b/apps/ember/src/components/ogre/widgets/ServerWidget.cpp
@@ -85,11 +85,12 @@ WidgetPluginCallback ServerWidget::registerWidget(GUIManager& guiManager) {
 }
 
 ServerWidget::ServerWidget(GUIManager& guiManager, Eris::Account& account) :
-		mWidget(guiManager.createWidget()),
-		mAccount(account),
-		mCharacterList(nullptr),
-		mCreateChar(nullptr),
-		mUseCreator(nullptr) {
+                mWidget(guiManager.createWidget()),
+                mAccount(account),
+                mCharacterList(nullptr),
+                mCreateChar(nullptr),
+                mUseCreator(nullptr),
+                mServerSettings() {
 
 	buildWidget();
 
@@ -247,10 +248,10 @@ void ServerWidget::showServerInfo(Eris::Connection& connection) {
 		CEGUI::Window* passwordBox = mWidget->getMainWindow()->getChild("InfoPanel/LoginPanel/PasswordEdit");
 		std::string savedUser;
 		std::string savedPass;
-		if (fetchCredentials(connection, savedUser, savedPass)) {
-			nameBox->setText(savedUser);
-			passwordBox->setText(savedPass);
-		}
+                if (fetchCredentials(connection, savedUser, savedPass)) {
+                        nameBox->setText(savedUser);
+                        passwordBox->setText(savedPass);
+                }
 
 		//Check if the protocol version from the server is newer than the one we support, and warn if that's the case.
 		if (sInfo.protocol_version > Ember::protocolVersion) {
@@ -264,20 +265,19 @@ void ServerWidget::showServerInfo(Eris::Connection& connection) {
 }
 
 bool ServerWidget::fetchCredentials(Eris::Connection& connection, std::string& user, std::string& pass) {
-	logger->debug("Fetching saved credentials.");
+        logger->debug("Fetching saved credentials.");
 
 	Eris::ServerInfo sInfo;
 	connection.getServerInfo(sInfo);
 
-	ServerSettingsCredentials serverCredentials(sInfo);
-	auto& serverSettings = ServerSettings::getSingleton();
-	if (serverSettings.findItem(serverCredentials, "username")) {
-		user = static_cast<std::string>(serverSettings.getItem(serverCredentials, "username"));
-	}
-	if (serverSettings.findItem(serverCredentials, "password")) {
-		pass = static_cast<std::string>(serverSettings.getItem(serverCredentials, "password"));
-	}
-	return !pass.empty() && !user.empty();
+        ServerSettingsCredentials serverCredentials(sInfo);
+        if (mServerSettings.findItem(serverCredentials, "username")) {
+                user = static_cast<std::string>(mServerSettings.getItem(serverCredentials, "username"));
+        }
+        if (mServerSettings.findItem(serverCredentials, "password")) {
+                pass = static_cast<std::string>(mServerSettings.getItem(serverCredentials, "password"));
+        }
+        return !pass.empty() && !user.empty();
 }
 
 bool ServerWidget::saveCredentials() {
@@ -297,11 +297,10 @@ bool ServerWidget::saveCredentials() {
 			// fetch info from widgets
 			const CEGUI::String& name = nameBox->getText();
 			const CEGUI::String& password = passwordBox->getText();
-			ServerSettingsCredentials serverCredentials(sInfo);
-			auto& serverSettings = ServerSettings::getSingleton();
-			serverSettings.setItem(serverCredentials, "username", name.c_str());
-			serverSettings.setItem(serverCredentials, "password", password.c_str());
-			serverSettings.writeToDisk();
+        ServerSettingsCredentials serverCredentials(sInfo);
+        mServerSettings.setItem(serverCredentials, "username", name.c_str());
+        mServerSettings.setItem(serverCredentials, "password", password.c_str());
+        mServerSettings.writeToDisk();
 			return true;
 		}
 		return false;

--- a/apps/ember/src/components/ogre/widgets/ServerWidget.h
+++ b/apps/ember/src/components/ogre/widgets/ServerWidget.h
@@ -29,6 +29,7 @@
 #include "services/server/AvatarTransferInfo.h"
 #include "framework/AutoCloseConnection.h"
 #include "services/server/ServerServiceSignals.h"
+#include "services/serversettings/ServerSettings.h"
 
 #include <Eris/Connection.h>
 #include <Eris/Avatar.h>
@@ -104,9 +105,11 @@ private:
 	 */
 	std::string mPreviewTypeName;
 
-	std::vector<AutoCloseConnection> mConnections;
+        std::vector<AutoCloseConnection> mConnections;
 
-	std::unique_ptr<Ember::AdminEntityCreator> mAdminEntityCreator;
+        std::unique_ptr<Ember::AdminEntityCreator> mAdminEntityCreator;
+
+        ServerSettings mServerSettings;
 
 	void gotAvatar(Eris::Avatar* avatar);
 
@@ -125,7 +128,7 @@ private:
 	bool EntityDestroyedOkButton_Click(const CEGUI::EventArgs& args);
 
 
-	static bool fetchCredentials(Eris::Connection& connection, std::string& user, std::string& pass);
+        bool fetchCredentials(Eris::Connection& connection, std::string& user, std::string& pass);
 
 	bool saveCredentials();
 

--- a/apps/ember/src/services/bindings/lua/LuaServerSettings.cpp
+++ b/apps/ember/src/services/bindings/lua/LuaServerSettings.cpp
@@ -26,9 +26,12 @@ template<>
 void registerLua<ServerSettings>(sol::table& space) {
 
 
-	auto serverSettings = space.new_usertype<ServerSettings>("ServerSettings", sol::no_constructor);
-	serverSettings["getSingleton"] = &ServerSettings::getSingleton;
-	serverSettings["getItem"] = &ServerSettings::getItem;
+        auto serverSettings = space.new_usertype<ServerSettings>("ServerSettings", sol::constructors<ServerSettings()>());
+        serverSettings["getItem"] = &ServerSettings::getItem;
+        serverSettings["findItem"] = &ServerSettings::findItem;
+        serverSettings["setItem"] = &ServerSettings::setItem;
+        serverSettings["eraseItem"] = &ServerSettings::eraseItem;
+        serverSettings["writeToDisk"] = &ServerSettings::writeToDisk;
 
 	space.new_usertype<ServerSettingsCredentials>("ServerSettingsCredentials",
 												  sol::constructors<ServerSettingsCredentials(const std::string&, const std::string&)>()

--- a/apps/ember/src/services/serversettings/ServerSettings.cpp
+++ b/apps/ember/src/services/serversettings/ServerSettings.cpp
@@ -27,15 +27,12 @@
 namespace Ember {
 
 ServerSettings::ServerSettings() :
-		Service("Server settings"),
-		mConfig(std::make_unique<varconf::Config>()) {
-	readFromDisk();
+                mConfig(std::make_unique<varconf::Config>()) {
+        readFromDisk();
 
 }
 
-ServerSettings::~ServerSettings() {
-	writeToDisk();
-}
+ServerSettings::~ServerSettings() { writeToDisk(); }
 
 std::string ServerSettings::getSectionForServerCredentials(const ServerSettingsCredentials& credentials) const {
 	//This should be expanded to a more complex way of assuring that the section returned is correct for the server credentials.

--- a/apps/ember/src/services/serversettings/ServerSettings.h
+++ b/apps/ember/src/services/serversettings/ServerSettings.h
@@ -20,8 +20,6 @@
 #ifndef EMBER_SERVICES_SERVERSETTINGS_H_
 #define EMBER_SERVICES_SERVERSETTINGS_H_
 
-#include "framework/Service.h"
-#include "framework/Singleton.h"
 #include <varconf/variable.h>
 #include <filesystem>
 #include <string>
@@ -36,19 +34,18 @@ namespace Ember {
 class ServerSettingsCredentials;
 
 /**
- * TODO: this should not be a service, instead make it into a simple class, perhaps stateless
  * @author Erik Ogenvik <erik@ogenvik.org>
  * @brief Stores server settings.
  *
- * This service stores settings for each server. It provides a simple interface for querying for existing settings as well as adding new ones.
- * While the settings will be stored to disk when the service shuts down, users are encouraged to call writeToDisk() as soon as any new settings has been added, to guarantee that no settings gets lost in the case of a crash.
+ * This class stores settings for each server. It provides a simple interface for querying for existing settings as well as adding new ones.
+ * While the settings will be stored to disk when the instance is destroyed, users are encouraged to call writeToDisk() as soon as any new settings has been added, to guarantee that no settings gets lost in the case of a crash.
  *
- * In order to query about the settings for a specific server an instance of ServerSettingsCredentials. This allows the service to manage server verification and lookup.
+ * In order to query about the settings for a specific server an instance of ServerSettingsCredentials. This allows the class to manage server verification and lookup.
  *
  * All server settings are stored in one file, by default "serversettings.conf", to be found in the Ember home config directory. Each server is represented by one section in this config file.
  * The mapping between servers and sections is handled by the getSectionForServerCredentials(...) method. This method currently only uses the host name to map servers to config file section, but it might be extended with more complex authentication methods for making sure that the right server is matched to the correct section.
  */
-class ServerSettings : public Service, public Singleton<ServerSettings> {
+class ServerSettings {
 public:
 	/**
 	 * @brief Ctor.
@@ -58,7 +55,7 @@ public:
 	/**
 	 * @brief Dtor.
 	 */
-	~ServerSettings() override;
+        ~ServerSettings();
 
 	/**
 	 * @brief Checks for the existence of a specific key.

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -86,3 +86,15 @@ if (TARGET cppunit::cppunit)
     #    add_test(NAME TestTerrain COMMAND TestTerrain)
 
 endif ()
+
+find_package(Catch2 3 REQUIRED)
+
+add_executable(ServerSettingsTest
+        ServerSettingsTest.cpp
+        ../src/services/serversettings/ServerSettings.cpp
+        ../src/services/serversettings/ServerSettingsCredentials.cpp
+        ../src/services/config/ConfigService.cpp)
+target_include_directories(ServerSettingsTest PRIVATE ../src)
+target_link_libraries(ServerSettingsTest Catch2::Catch2WithMain varconf)
+add_test(NAME ServerSettingsTest COMMAND ServerSettingsTest)
+add_dependencies(check ServerSettingsTest)

--- a/apps/ember/tests/ServerSettingsTest.cpp
+++ b/apps/ember/tests/ServerSettingsTest.cpp
@@ -1,0 +1,36 @@
+#include <services/serversettings/ServerSettings.h>
+#include <services/serversettings/ServerSettingsCredentials.h>
+#include <services/config/ConfigService.h>
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <spdlog/logger.h>
+
+std::shared_ptr<spdlog::logger> logger = std::make_shared<spdlog::logger>("test");
+
+TEST_CASE("ServerSettings persist values", "[ServerSettings]") {
+    using namespace Ember;
+    auto tmpDir = std::filesystem::temp_directory_path() / "serversettings-test";
+    std::filesystem::remove_all(tmpDir);
+    std::filesystem::create_directories(tmpDir);
+
+    ConfigService config(tmpDir);
+    config.setHomeDirectory(tmpDir.string());
+
+    {
+        ServerSettings settings;
+        ServerSettingsCredentials creds("localhost", "testserver");
+        settings.setItem(creds, "key", "value");
+        settings.writeToDisk();
+    }
+
+    {
+        ServerSettings settings;
+        ServerSettingsCredentials creds("localhost", "testserver");
+        REQUIRE(settings.findItem(creds, "key"));
+        auto val = settings.getItem(creds, "key");
+        REQUIRE(static_cast<std::string>(val) == "value");
+    }
+
+    std::filesystem::remove_all(tmpDir);
+}
+


### PR DESCRIPTION
## Summary
- refactor ServerSettings into a regular class without Service/Singleton
- inject ServerSettings instances into widgets and Lua bindings
- add unit test checking configuration persistence

## Testing
- `g++ -std=c++20 apps/ember/tests/ServerSettingsTest.cpp ... -lCatch2` *(fails: fatal error: Eris/ServerInfo.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b330a0bd94832d81fb08d29f23d499