### PR TITLE
Add serialno to connect command and improve flush usage

### DIFF
--- a/apps/cyphesis/src/tools/Interactive.cpp
+++ b/apps/cyphesis/src/tools/Interactive.cpp
@@ -675,14 +675,13 @@ void Interactive::exec(const std::string& cmd, const std::string& arg) {
 			cmap->setAttr("hostname", args[0]);
 			cmap->setAttr("port", strtol(args[1].c_str(), nullptr, 10));
 
-			Connect m;
-			m->setArgs1(cmap);
-			// No serialno yet
-			// FIXME add serialno once Juncture context can handle this
+                        Connect m;
+                        m->setArgs1(cmap);
+                        m->setSerialno(newSerialNo());
 
-			command_context->setFromContext(m);
+                        command_context->setFromContext(m);
 
-			send(m);
+                        send(m);
 		}
 	} else if (cmd == "add_agent") {
 		std::string agent_type("creator");
@@ -757,14 +756,13 @@ void Interactive::exec(const std::string& cmd, const std::string& arg) {
 			reply_expected = false;
 		}
 	} else if (cmd == "flush") {
-		if (arg.empty()) {
-			// FIXME usage
-			std::cout << "Please specify the type to flush" << std::endl;
-			reply_expected = false;
-		} else {
-			runTask(std::make_shared<Flusher>(command_context), arg);
-			reply_expected = false;
-		}
+                if (arg.empty()) {
+                        std::cout << "usage: flush <type>" << std::endl;
+                        reply_expected = false;
+                } else {
+                        runTask(std::make_shared<Flusher>(command_context), arg);
+                        reply_expected = false;
+                }
 	} else if (cmd == "cancel") {
 		if (endTask() != 0) {
 			std::cout << "No task currently running" << std::endl;

--- a/apps/cyphesis/tests/CMakeLists.txt
+++ b/apps/cyphesis/tests/CMakeLists.txt
@@ -586,6 +586,7 @@ wf_add_test(tools/FlusherTest.cpp ../src/tools/Flusher.cpp
 wf_add_test(tools/OperationMonitorTest.cpp ../src/tools/OperationMonitor.cpp
         ../src/common/ClientTask.cpp)
 wf_add_test(tools/EntityExporterTest.cpp ../src/tools/EntityExporterBase.cpp)
+wf_add_test(tools/InteractiveCommandTest.cpp ../src/tools/Interactive.cpp ../src/tools/Flusher.cpp ../src/tools/OperationMonitor.cpp ../src/tools/EntityExporterBase.cpp ../src/tools/EntityExporter.cpp ../src/tools/EntityImporterBase.cpp ../src/tools/EntityImporter.cpp ../src/tools/AdminClient.cpp ../src/tools/IdContext.cpp ../src/tools/AccountContext.cpp ../src/tools/AvatarContext.cpp ../src/tools/ConnectionContext.cpp ../src/tools/JunctureContext.cpp)
 
 
 # PYTHON_TESTS

--- a/apps/cyphesis/tests/tools/InteractiveCommandTest.cpp
+++ b/apps/cyphesis/tests/tools/InteractiveCommandTest.cpp
@@ -1,0 +1,51 @@
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#ifndef DEBUG
+#define DEBUG
+#endif
+
+#include "tools/Interactive.h"
+#include "tools/JunctureContext.h"
+
+#include <Atlas/Objects/Operation.h>
+#include <boost/asio/io_context.hpp>
+
+#include <cassert>
+#include <sstream>
+
+class TestInteractive : public Interactive {
+public:
+    using Interactive::Interactive;
+    Atlas::Objects::Operation::RootOperation lastSent;
+
+    void send(const Atlas::Objects::Operation::RootOperation& op) override {
+        lastSent = op;
+        reply_flag = true;
+    }
+};
+
+int main() {
+    boost::asio::io_context io;
+    Atlas::Objects::Factories factories;
+
+    TestInteractive interactive(factories, io);
+    auto ctx = std::make_shared<JunctureContext>(interactive, "1");
+    interactive.addCurrentContext(ctx);
+
+    interactive.exec("connect", "localhost 6767");
+    assert(!interactive.lastSent->isDefaultSerialno());
+
+    std::ostringstream out;
+    auto* oldBuf = std::cout.rdbuf(out.rdbuf());
+    interactive.exec("flush", "");
+    std::cout.rdbuf(oldBuf);
+    assert(out.str().find("usage: flush <type>") != std::string::npos);
+
+    return 0;
+}
+
+extern "C" {
+int rl_set_prompt(const char*) { return 0; }
+void rl_redisplay() {}
+}


### PR DESCRIPTION
## Summary
- assign a serial number when issuing the `connect` command
- show a usage hint when `flush` is called without a type
- add regression test for `connect` and `flush` commands

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread) (Required is exact version "1.87.0"))*

------
https://chatgpt.com/codex/tasks/task_e_68b33838f46c832d9a9bf7602888d937