### PR TITLE
Add optional binreloc support to cyphesis

### DIFF
--- a/apps/cyphesis/CMakeLists.txt
+++ b/apps/cyphesis/CMakeLists.txt
@@ -155,7 +155,12 @@ else (RSYNC_CMD)
     )
 endif (RSYNC_CMD)
 
-##TODO: check for binreloc?
+option(CYPHESIS_USE_BINRELOC "Enable binreloc for relocatable installs" ${UNIX})
+if (CYPHESIS_USE_BINRELOC)
+    message(STATUS "binreloc enabled")
+else ()
+    message(STATUS "binreloc disabled")
+endif ()
 
 #We'll use xmllint for validating schemas of some of our xml files.
 find_program(XMLLINT xmllint)

--- a/apps/cyphesis/README.md
+++ b/apps/cyphesis/README.md
@@ -125,6 +125,12 @@ the Python specific allocator. For example if you want to profile memory usage.
 This can be enabled by setting the environment variable "PYTHONMALLOC" to something (doesn't matter what).
 Upon startup Cyphesis will then use malloc, and write a line about this to the log.
 
+## Binreloc support
+
+Cyphesis can use the [binreloc](http://autopackage.org/docs/binreloc/) library to locate its data files relative to the executable at runtime.
+This makes it possible to move the installation without recompiling. Binreloc is enabled by default on Unix-like systems but can be disabled by
+passing `-DCYPHESIS_USE_BINRELOC=OFF` to CMake. When disabled, compiled-in paths are used instead.
+
 ## Performance measuring through Remotery
 
 Performance tracking through [Remotery](https://github.com/Celtoys/Remotery) is built in,

--- a/apps/cyphesis/src/common/CMakeLists.txt
+++ b/apps/cyphesis/src/common/CMakeLists.txt
@@ -55,10 +55,14 @@ target_link_libraries(cyphesis-common PUBLIC
         external-libxdg-basedir
         spdlog::spdlog
         external-saf
-        external-binreloc
         external-bytesize
         Microsoft.GSL::GSL
 )
+
+if (CYPHESIS_USE_BINRELOC)
+    target_link_libraries(cyphesis-common PUBLIC external-binreloc)
+    target_compile_definitions(cyphesis-common PUBLIC CYPHESIS_USE_BINRELOC)
+endif ()
 
 target_compile_features(cyphesis-common PUBLIC cxx_std_20)
 

--- a/apps/cyphesis/src/common/system_prefix.cpp
+++ b/apps/cyphesis/src/common/system_prefix.cpp
@@ -16,21 +16,30 @@
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 
+#ifdef CYPHESIS_USE_BINRELOC
 #include "binreloc.h"
+#endif
 #include "globals.h"
 #include "system.h"
 #include <iostream>
 #include <fmt/format.h>
 
 void getinstallprefix() {
-	BrInitError error;
-	if (br_init(&error) == 0) {
-		std::cerr << "Error when setting up BinReloc: " << error << std::endl;
-		return;
-	}
+#ifdef CYPHESIS_USE_BINRELOC
+        BrInitError error;
+        if (br_init(&error) == 0) {
+                std::cerr << "Error when setting up BinReloc: " << error << std::endl;
+                return;
+        }
 
-	etc_directory = br_find_etc_dir("");
-	share_directory = br_find_data_dir("data");
-	var_directory = fmt::format("{}/var", br_find_prefix(""));
-	bin_directory = br_find_bin_dir("bin");
+        etc_directory = br_find_etc_dir("");
+        share_directory = br_find_data_dir("data");
+        var_directory = fmt::format("{}/var", br_find_prefix(""));
+        bin_directory = br_find_bin_dir("bin");
+#else
+        etc_directory = SYSCONFDIR;
+        share_directory = DATADIR;
+        var_directory = LOCALSTATEDIR;
+        bin_directory = BINDIR;
+#endif
 }


### PR DESCRIPTION
## Summary
- add CMake option to toggle binreloc usage in cyphesis
- conditionally build/link binreloc support and fallback to compile-time paths
- document optional binreloc usage in cyphesis build docs

## Testing
- ⚠️ `cmake -S . -B build -DCYPHESIS_USE_BINRELOC=ON` (failed: Could not find package configuration file provided by "spdlog")


------
https://chatgpt.com/codex/tasks/task_e_68b338462070832d932b18e4a916a155