### PR TITLE
Watch all configured asset directories

### DIFF
--- a/apps/cyphesis/src/common/AssetsManager.cpp
+++ b/apps/cyphesis/src/common/AssetsManager.cpp
@@ -21,6 +21,7 @@
 #include "FileSystemObserver.h"
 #include "globals.h"
 #include "log.h"
+#include <vector>
 
 namespace {
 auto callback(std::map<std::filesystem::path, std::list<std::function<void(const std::filesystem::path& path)>>>& callbacks,
@@ -65,35 +66,61 @@ auto callback(std::map<std::filesystem::path, std::list<std::function<void(const
 AssetsManager::AssetsManager(std::unique_ptr<FileSystemObserver> file_system_observer)
 		: m_file_system_observer(std::move(file_system_observer)) {
 
-	auto observerCallback = callback(m_callbacks, m_directoryCallbacks);
+        auto observerCallback = callback(m_callbacks, m_directoryCallbacks);
 
-	//TODO: implement for all asset paths
-	m_file_system_observer->add_directory(std::filesystem::path(share_directory) / "cyphesis" / "scripts", observerCallback);
-	m_file_system_observer->add_directory(std::filesystem::path(share_directory) / "cyphesis" / "rulesets", observerCallback);
+        // Enumerate all configured share directories and register both scripts and rulesets paths.
+        std::vector<std::string> share_dirs;
+        boost::algorithm::split(share_dirs, share_directory, boost::is_any_of(":"));
+        for (const auto& dir: share_dirs) {
+                if (dir.empty()) {
+                        continue;
+                }
+                m_file_system_observer->add_directory(std::filesystem::path(dir) / "cyphesis" / "scripts", observerCallback);
+                m_file_system_observer->add_directory(std::filesystem::path(dir) / "cyphesis" / "rulesets", observerCallback);
+        }
 
-	m_file_system_observer->add_directory(std::filesystem::path(etc_directory) / "cyphesis", observerCallback);
+        // Enumerate all configured etc directories.
+        std::vector<std::string> etc_dirs;
+        boost::algorithm::split(etc_dirs, etc_directory, boost::is_any_of(":"));
+        for (const auto& dir: etc_dirs) {
+                if (dir.empty()) {
+                        continue;
+                }
+                m_file_system_observer->add_directory(std::filesystem::path(dir) / "cyphesis", observerCallback);
+        }
 }
 
 AssetsManager::~AssetsManager() = default;
 
 void AssetsManager::observeAssetsDirectory() {
-	std::filesystem::path assetsDirectory(assets_directory);
-	if (std::filesystem::exists(assetsDirectory)) {
-		mAssetsPath = assetsDirectory;
-	} else {
-		mAssetsPath = std::filesystem::path(CYPHESIS_RAW_ASSETS_DIRECTORY);
-		if (std::filesystem::exists(mAssetsPath)) {
-			spdlog::info("Could not find any assets directory in '{}' but found raw assets in '{}'.", assets_directory, CYPHESIS_RAW_ASSETS_DIRECTORY);
-		} else {
-			spdlog::error("Could not find neither assets directory in '{}' or found raw assets in '{}'. Will continue but the server will probably not function correctly.", assets_directory,
-						  CYPHESIS_RAW_ASSETS_DIRECTORY);
-		}
-	}
+        std::vector<std::string> asset_dirs;
+        boost::algorithm::split(asset_dirs, assets_directory, boost::is_any_of(":"));
 
-	if (!mAssetsPath.empty()) {
-		auto observerCallback = callback(m_callbacks, m_directoryCallbacks);
-		m_file_system_observer->add_directory(std::filesystem::path(mAssetsPath), observerCallback);
-	}
+        auto observerCallback = callback(m_callbacks, m_directoryCallbacks);
+
+        for (const auto& dir: asset_dirs) {
+                if (dir.empty()) {
+                        continue;
+                }
+                std::filesystem::path assetsDirectory(dir);
+                if (std::filesystem::exists(assetsDirectory)) {
+                        if (mAssetsPath.empty()) {
+                                mAssetsPath = assetsDirectory;
+                        }
+                        m_file_system_observer->add_directory(assetsDirectory, observerCallback);
+                }
+        }
+
+        if (mAssetsPath.empty()) {
+                mAssetsPath = std::filesystem::path(CYPHESIS_RAW_ASSETS_DIRECTORY);
+                if (std::filesystem::exists(mAssetsPath)) {
+                        spdlog::info("Could not find any assets directory in '{}' but found raw assets in '{}'.", assets_directory, CYPHESIS_RAW_ASSETS_DIRECTORY);
+                        m_file_system_observer->add_directory(mAssetsPath, observerCallback);
+                } else {
+                        spdlog::error("Could not find neither assets directory in '{}' or found raw assets in '{}'. Will continue but the server will probably not function correctly.", assets_directory,
+                                                  CYPHESIS_RAW_ASSETS_DIRECTORY);
+                }
+        }
 }
 
 

--- a/apps/cyphesis/tests/CMakeLists.txt
+++ b/apps/cyphesis/tests/CMakeLists.txt
@@ -197,6 +197,7 @@ wf_add_test(rules/EntityKitTest.cpp)
 wf_add_test(common/LinkTest.cpp ../src/common/Link.cpp)
 wf_add_test(common/CommSocketTest.cpp)
 wf_add_test(common/FileSystemObserverIntegrationTest.cpp ../src/common/FileSystemObserver.cpp)
+wf_add_test(common/AssetsManagerIntegrationTest.cpp ../src/common/AssetsManager.cpp ../src/common/FileSystemObserver.cpp)
 
 # PHYSICS_TESTS
 wf_add_test(physics/BBoxTest.cpp ../src/physics/BBox.cpp ../src/common/const.cpp)

--- a/apps/cyphesis/tests/common/AssetsManagerIntegrationTest.cpp
+++ b/apps/cyphesis/tests/common/AssetsManagerIntegrationTest.cpp
@@ -1,0 +1,81 @@
+#include "../TestBase.h"
+#include "common/AssetsManager.h"
+#include "common/FileSystemObserver.h"
+#include "common/globals.h"
+
+#include <boost/asio/io_context.hpp>
+#include <filesystem>
+#include <fstream>
+#include <thread>
+#include <chrono>
+
+class AssetsManagerIntegrationTest : public Cyphesis::TestBase {
+public:
+    void setup() override {}
+    void teardown() override {}
+
+    void test_allPathsTriggerReload() {
+        namespace fs = std::filesystem;
+        auto temp = fs::temp_directory_path();
+
+        fs::path share1 = temp / "am_share1";
+        fs::path share2 = temp / "am_share2";
+        fs::path etc1 = temp / "am_etc1";
+        fs::path asset1 = temp / "am_asset1";
+        fs::path asset2 = temp / "am_asset2";
+
+        fs::create_directories(share1 / "cyphesis" / "scripts");
+        fs::create_directories(share2 / "cyphesis" / "scripts");
+        fs::create_directories(etc1 / "cyphesis");
+        fs::create_directories(asset1);
+        fs::create_directories(asset2);
+
+        share_directory = (share1.string() + ":" + share2.string());
+        etc_directory = etc1.string();
+        assets_directory = (asset1.string() + ":" + asset2.string());
+
+        boost::asio::io_context io_context;
+        auto observer = std::make_unique<FileSystemObserver>(io_context);
+        AssetsManager manager(std::move(observer));
+        manager.observeAssetsDirectory();
+
+        fs::path shareFile1 = share1 / "cyphesis" / "scripts" / "file1.txt";
+        fs::path shareFile2 = share2 / "cyphesis" / "scripts" / "file2.txt";
+        fs::path assetFile1 = asset1 / "asset1.txt";
+        fs::path assetFile2 = asset2 / "asset2.txt";
+
+        bool share1Triggered = false;
+        bool share2Triggered = false;
+        bool asset1Triggered = false;
+        bool asset2Triggered = false;
+
+        manager.observeFile(shareFile1, [&](const fs::path&){ share1Triggered = true; });
+        manager.observeFile(shareFile2, [&](const fs::path&){ share2Triggered = true; });
+        manager.observeFile(assetFile1, [&](const fs::path&){ asset1Triggered = true; });
+        manager.observeFile(assetFile2, [&](const fs::path&){ asset2Triggered = true; });
+
+        std::ofstream(shareFile1) << "data";
+        std::ofstream(shareFile2) << "data";
+        std::ofstream(assetFile1) << "data";
+        std::ofstream(assetFile2) << "data";
+
+        for (int i = 0; i < 20; ++i) {
+            io_context.poll();
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+
+        ASSERT_TRUE(share1Triggered);
+        ASSERT_TRUE(share2Triggered);
+        ASSERT_TRUE(asset1Triggered);
+        ASSERT_TRUE(asset2Triggered);
+    }
+
+    AssetsManagerIntegrationTest() {
+        ADD_TEST(AssetsManagerIntegrationTest::test_allPathsTriggerReload);
+    }
+};
+
+int main() {
+    AssetsManagerIntegrationTest t;
+    return t.run();
+}


### PR DESCRIPTION
## Summary
- monitor scripts, rulesets, and config directories from all configured paths
- observe every configured assets directory for changes
- add integration test verifying asset path change callbacks

## Testing
- ⚠️ `cmake -S . -B build` (missing cppunit & spdlog)
- ⚠️ `conan install . --output-folder=build --build=missing -o with_client=False -o with_server=False` (build cancelled due to time)


------
https://chatgpt.com/codex/tasks/task_e_68b8b9846f00832d8a92e600f68ce5ee