### PR TITLE
Add thread-local Python log context with spdlog

### DIFF
--- a/apps/cyphesis/src/pythonbase/Python_API.cpp
+++ b/apps/cyphesis/src/pythonbase/Python_API.cpp
@@ -246,6 +246,7 @@ void observe_python_directories(boost::asio::io_context& io_context, AssetsManag
 
 void init_python_api(std::vector<std::function<std::string()>> initFunctions, std::vector<std::string> scriptDirectories, bool log_stdout)
 {
+    python_log::install_python_log_formatter();
     //If we're using the system Python installation then everything should be setup for Python to use.
     //But if we're instead using something like a Conan version where Python is installed in a different place
     //we need to tell Python where to find its stuff. This is done through the PYTHONHOME environment variable.

--- a/apps/cyphesis/src/pythonbase/README.md
+++ b/apps/cyphesis/src/pythonbase/README.md
@@ -1,0 +1,12 @@
+# Python Base Utilities
+
+## Logging Context
+
+`PythonLogGuard` injects contextual prefixes into spdlog output using thread-local storage. The guard stores a callback that returns a string prefix. When active, every log message on the same thread is automatically prefixed with that string.
+
+```cpp
+PythonLogGuard guard([](){ return "[script] "; });
+spdlog::info("hello"); // produces: [script] hello
+```
+
+The formatter is installed automatically by `init_python_api`, but custom loggers can opt-in by calling `python_log::install_python_log_formatter(logger)`. Because the prefix is thread-local, concurrent threads may log independently without corrupting each other's output.

--- a/apps/cyphesis/tests/CMakeLists.txt
+++ b/apps/cyphesis/tests/CMakeLists.txt
@@ -156,6 +156,7 @@ wf_add_test(modules/RefTest.cpp)
 
 wf_add_test(common/OperationsDispatcherTest.cpp)
 wf_add_test(common/logTest.cpp ../src/common/log.cpp)
+wf_add_test(common/PythonLogGuardTest.cpp)
 #wf_add_test(common/InheritanceTest.cpp ../src/common/Inheritance.cpp ../src/common/custom.cpp)
 wf_add_test(rules/simulation/PropertyTest.cpp ../src/common/Property.cpp ../src/rules/simulation/EntityProperties.cpp ../src/common/type_utils.cpp ../src/common/PropertyUtil.cpp)
 wf_add_test(common/systemTest.cpp ../src/common/system.cpp)

--- a/apps/cyphesis/tests/common/PythonLogGuardTest.cpp
+++ b/apps/cyphesis/tests/common/PythonLogGuardTest.cpp
@@ -1,0 +1,46 @@
+// Verify that PythonLogGuard prefixes log messages in a thread-safe manner.
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#ifndef DEBUG
+#define DEBUG
+#endif
+
+#include "pythonbase/Python_API.h"
+
+#include <spdlog/sinks/ostream_sink.h>
+#include <cassert>
+#include <thread>
+#include <sstream>
+#include <vector>
+
+int main()
+{
+    std::ostringstream oss;
+    auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+    auto logger = std::make_shared<spdlog::logger>("test", sink);
+    python_log::install_python_log_formatter(logger);
+    auto old = spdlog::default_logger();
+    spdlog::set_default_logger(logger);
+
+    const int num_threads = 4;
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([i]() {
+            PythonLogGuard guard([i]() { return "[T" + std::to_string(i) + "] "; });
+            spdlog::info("message {}", i);
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    spdlog::set_default_logger(old);
+    auto out = oss.str();
+    for (int i = 0; i < num_threads; ++i) {
+        std::string expected = "[T" + std::to_string(i) + "] message " + std::to_string(i);
+        assert(out.find(expected) != std::string::npos);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add thread-local log prefix via custom spdlog formatter
- document PythonLogGuard usage
- test concurrent logging prefixes

## Testing
- `/tmp/PythonLogGuardTest`
- `cmake -S . -B build` *(fails: Could NOT find Boost)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b9837944832d941169c4c11e8cdf