### PR TITLE
Handle world to entity coordinate conversion across parent chain

### DIFF
--- a/apps/ember/src/components/ogre/Avatar.cpp
+++ b/apps/ember/src/components/ogre/Avatar.cpp
@@ -587,7 +587,16 @@ WFMath::Vector<3> Avatar::getClientSideAvatarVelocity() const {
 }
 
 void Avatar::viewEntityDeleted() {
-	EventAvatarEntityDestroyed();
+        EventAvatarEntityDestroyed();
+}
+
+WFMath::Point<3> Avatar::worldToEntityCoords(const WFMath::Point<3>& worldPos,
+                                             const Eris::Entity& entity) {
+        if (!entity.getLocation()) {
+                return worldPos;
+        }
+        auto parentCoords = worldToEntityCoords(worldPos, *entity.getLocation());
+        return parentCoords.toLocalCoords(entity.getPredictedPos(), entity.getPredictedOrientation());
 }
 
 void Avatar::useTool(const EmberEntity& tool,
@@ -622,24 +631,17 @@ void Avatar::populateUsageArgs(Atlas::Objects::Entity::RootEntity& entity,
 							   WFMath::Vector<3> direction) {
 	for (auto& param: params) {
 		Atlas::Message::ListType list;
-		if (param.second.type == "entity" || param.second.type == "entity_location") {
-			if (target) {
-				Atlas::Objects::Entity::RootEntity entityArg;
-				entityArg->setId(target->getId());
-				if (posInWorld.isValid()) {
-					if (mErisAvatarEntity.getLocation() == target) {
-						//We're picking in our parent location
-						entityArg->setPosAsList(Atlas::Message::Element(posInWorld.toAtlas()).List());
-					} else {
-						//pos must be relative to the entity
-						//TODO: walk up and down the entity hierarchy; the current code only works for entities that share location
-						auto localPos = posInWorld.toLocalCoords(target->getPredictedPos(), target->getPredictedOrientation());
-						entityArg->setPosAsList(Atlas::Message::Element(localPos.toAtlas()).List());
-					}
-				}
-				list.emplace_back(entityArg->asMessage());
-			}
-		} else if (param.second.type == "position") {
+                if (param.second.type == "entity" || param.second.type == "entity_location") {
+                        if (target) {
+                                Atlas::Objects::Entity::RootEntity entityArg;
+                                entityArg->setId(target->getId());
+                                if (posInWorld.isValid()) {
+                                        auto localPos = worldToEntityCoords(posInWorld, *target);
+                                        entityArg->setPosAsList(Atlas::Message::Element(localPos.toAtlas()).List());
+                                }
+                                list.emplace_back(entityArg->asMessage());
+                        }
+                } else if (param.second.type == "position") {
 			if (posInWorld.isValid()) {
 				list.emplace_back(posInWorld.toAtlas());
 			}

--- a/apps/ember/src/components/ogre/Avatar.h
+++ b/apps/ember/src/components/ogre/Avatar.h
@@ -394,13 +394,28 @@ protected:
 	 *
 	 * Call this when the location of the entity, or its graphical representation, has changed.
 	 */
-	void attachCameraToEntity();
+        void attachCameraToEntity();
+
+/**
+ * @brief Convert a world position into coordinates relative to an entity.
+ *
+ * The supplied position is expected to be in the coordinate system of the
+ * top level parent of the entity. The returned position will be in the
+ * entity's local coordinate system.
+ *
+ * @param worldPos Position expressed in world coordinates.
+ * @param entity   Target entity for which the position should be expressed
+ *                 in local coordinates.
+ * @return Position in the local coordinate system of @a entity.
+ */
+static WFMath::Point<3> worldToEntityCoords(const WFMath::Point<3>& worldPos,
+       const Eris::Entity& entity);
 
 
-	void populateUsageArgs(Atlas::Objects::Entity::RootEntity& entity,
-						   const std::map<std::string, Eris::UsageParameter>& params,
-						   const Eris::Entity* target,
-						   const WFMath::Point<3>& posInWorld,
+        void populateUsageArgs(Atlas::Objects::Entity::RootEntity& entity,
+                                                   const std::map<std::string, Eris::UsageParameter>& params,
+                                                   const Eris::Entity* target,
+                                                   const WFMath::Point<3>& posInWorld,
 						   WFMath::Vector<3> direction);
 };
 

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ if (TARGET cppunit::cppunit)
             TestOgreView.cpp
             ConvertTestCase.cpp
             ModelMountTestCase.cpp
+            NestedEntityTestCase.cpp
             $<TARGET_OBJECTS:ember-ogre>
             $<TARGET_OBJECTS:ember-caelum>
             $<TARGET_OBJECTS:ember-meshtree>

--- a/apps/ember/tests/NestedEntityTestCase.cpp
+++ b/apps/ember/tests/NestedEntityTestCase.cpp
@@ -1,0 +1,36 @@
+#include "NestedEntityTestCase.h"
+#include "components/ogre/Avatar.h"
+#include <Eris/Entity.h>
+#include <Eris/Task.h>
+#include <wfmath/atlasconv.h>
+#include <wfmath/point.h>
+
+using namespace Ember::OgreView;
+using namespace WFMath;
+
+namespace Ember {
+void NestedEntityTestCase::testWorldToEntityCoords() {
+        Eris::Entity::EntityContext context{};
+        context.fetchEntity = [](const std::string&) -> Eris::Entity* { return nullptr; };
+        context.getEntity = [](const std::string&) -> Eris::Entity* { return nullptr; };
+        context.taskUpdated = [](Eris::Task&) {};
+
+        Eris::Entity root{"root", nullptr, context};
+        root.setProperty("pos", Point<3>(0,0,0).toAtlas());
+
+        Eris::Entity parent{"parent", nullptr, context};
+        parent.setProperty("pos", Point<3>(10,0,0).toAtlas());
+        parent.setLocation(&root);
+
+        Eris::Entity child{"child", nullptr, context};
+        child.setProperty("pos", Point<3>(0,0,5).toAtlas());
+        child.setLocation(&parent);
+
+        Point<3> worldPos(15,0,7);
+        auto childLocal = Avatar::worldToEntityCoords(worldPos, child);
+        CPPUNIT_ASSERT(childLocal == Point<3>(5,0,2));
+
+        auto parentLocal = Avatar::worldToEntityCoords(worldPos, parent);
+        CPPUNIT_ASSERT(parentLocal == Point<3>(5,0,7));
+}
+}

--- a/apps/ember/tests/NestedEntityTestCase.h
+++ b/apps/ember/tests/NestedEntityTestCase.h
@@ -1,0 +1,11 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace Ember {
+class NestedEntityTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(NestedEntityTestCase);
+        CPPUNIT_TEST(testWorldToEntityCoords);
+        CPPUNIT_TEST_SUITE_END();
+public:
+        void testWorldToEntityCoords();
+};
+}

--- a/apps/ember/tests/TestOgreView.cpp
+++ b/apps/ember/tests/TestOgreView.cpp
@@ -3,9 +3,11 @@
 
 #include "ConvertTestCase.h"
 #include "ModelMountTestCase.h"
+#include "NestedEntityTestCase.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ConvertTestCase);
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
+CPPUNIT_TEST_SUITE_REGISTRATION( Ember::NestedEntityTestCase );
 
 int main(int argc, char** argv) {
 	CppUnit::TextUi::TestRunner runner;


### PR DESCRIPTION
## Summary
- Recursively convert world positions to entity-local coordinates via parent chain traversal
- Use new conversion when populating tool usage arguments
- Add nested entity tests for coordinate conversion

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration files for cppunit and Microsoft.GSL)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b9815cb4832d92111644ff30125e