### PR TITLE
Enforce C++20 globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.18)
 
 project(Worldforge)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 option(PREBUILT_DIR "Directory for prebuilt artifacts" "${CMAKE_SOURCE_DIR}/prebuilt")
 set(CMAKE_INSTALL_PREFIX "${PREBUILT_DIR}" CACHE PATH "Install path prefix" FORCE)
 

--- a/apps/cyphesis/src/common/CMakeLists.txt
+++ b/apps/cyphesis/src/common/CMakeLists.txt
@@ -64,8 +64,6 @@ if (CYPHESIS_USE_BINRELOC)
     target_compile_definitions(cyphesis-common PUBLIC CYPHESIS_USE_BINRELOC)
 endif ()
 
-target_compile_features(cyphesis-common PUBLIC cxx_std_20)
-
 target_compile_definitions(cyphesis-common PUBLIC
         -DBINDIR="${CMAKE_INSTALL_FULL_BINDIR}"
         -DDATADIR="${CMAKE_INSTALL_FULL_DATADIR}"

--- a/apps/ember/src/main/CMakeLists.txt
+++ b/apps/ember/src/main/CMakeLists.txt
@@ -1,6 +1,5 @@
 #Use WIN32 to specify that on Windows it should be a non-console app.
 add_executable(ember WIN32)
-target_compile_features(ember PUBLIC cxx_std_20)
 target_sources(ember PUBLIC
         Application.cpp
         ConfigBoundLogObserver.cpp
@@ -45,7 +44,6 @@ if (WF_USE_WIDGET_PLUGINS)
     target_link_libraries(ember-shared
             ${ember-libraries}
     )
-    target_compile_features(ember-shared PUBLIC cxx_std_20)
 
     #The idea here is to allow symbol exports from the main exe, so that the plugins can import them. Not sure if it works though.
     set_property(TARGET ember-shared PROPERTY ENABLE_EXPORTS 1)

--- a/libs/atlas/CMakeLists.txt
+++ b/libs/atlas/CMakeLists.txt
@@ -21,7 +21,6 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
 
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/libs/eris/CMakeLists.txt
+++ b/libs/eris/CMakeLists.txt
@@ -9,7 +9,6 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
 
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/libs/mercator/CMakeLists.txt
+++ b/libs/mercator/CMakeLists.txt
@@ -16,7 +16,6 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
             SOVERSION ${SOVERSION}
     )
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/libs/squall/CMakeLists.txt
+++ b/libs/squall/CMakeLists.txt
@@ -26,7 +26,6 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
 
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/libs/varconf/CMakeLists.txt
+++ b/libs/varconf/CMakeLists.txt
@@ -10,7 +10,6 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/libs/wfmath/CMakeLists.txt
+++ b/libs/wfmath/CMakeLists.txt
@@ -10,7 +10,6 @@ set(DESCRIPTION "A math library for the Worldforge system.")
 macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
-    target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
     target_include_directories(${_LIB_NAME}
             PUBLIC


### PR DESCRIPTION
## Summary
- Set the project-wide C++ standard to 20 and require it
- Remove redundant per-target C++20 compile features so targets inherit the global standard

## Testing
- `conan install . --output-folder=build --build=missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True` *(fails: Package 'ogre-next/2.3.0@worldforge' not resolved)*
- `cmake -S . -B build` *(fails: Could not find package configuration files for cppunit and spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c192463c832dbbdf3431fddeb83c