### PR TITLE
Derive Conan package version from Git

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMakeDeps, CMakeToolchain
@@ -6,14 +7,25 @@ from conan.tools.microsoft import is_msvc
 
 
 class Worldforge(ConanFile):
-    version = "0.1.0"
     package_type = "application"
     settings = "os", "arch", "compiler", "build_type"
     url = "https://github.com/worldforge"
     homepage = "https://www.worldforge.org"
-    name = "Worldforge"
     license = "GPL-3.0-or-later"
     author = "Erik Ogenvik <erik@ogenvik.org>"
+
+    def set_name(self):
+        self.name = "Worldforge"
+
+    def set_version(self):
+        try:
+            self.version = subprocess.check_output(
+                ["git", "describe"],
+                cwd=self.recipe_folder,
+                encoding="utf-8",
+            ).strip()
+        except Exception:
+            self.version = "0.9.0-dev"
 
     options = {
         "with_client": [True, False],


### PR DESCRIPTION
## Summary
- fetch package version from `git describe` during `set_version`
- default to `0.9.0-dev` when git metadata is unavailable
- migrate to `set_name`/`set_version` hooks per Conan best practices

## Testing
- `python -m py_compile conanfile.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c192b88c832d869317a6665f0b69