### PR TITLE
refactor: apply warning flags per target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,11 @@ else ()
     endif ()
 endif ()
 MESSAGE(STATUS "Setting compiler warnings to '${WF_WARNING_FLAGS}'")
-#Do this globally for the whole repo
-add_compile_options(${WF_WARNING_FLAGS})
+
+# Helper applying warning flags to internal targets only
+function(wf_apply_warnings TARGET)
+    target_compile_options(${TARGET} PRIVATE ${WF_WARNING_FLAGS})
+endfunction()
 
 option(WORLDFORGE_ENABLE_COVERAGE "Enable coverage flags for Debug builds" OFF)
 if (WORLDFORGE_ENABLE_COVERAGE AND CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/apps/cyphesis/src/CMakeLists.txt
+++ b/apps/cyphesis/src/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_compile_options(${_LIB_NAME} ${WF_WARNING_FLAGS})
-
 add_subdirectory(physics)
 add_subdirectory(common)
 add_subdirectory(modules)

--- a/apps/cyphesis/src/client/CMakeLists.txt
+++ b/apps/cyphesis/src/client/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(cyphesis-client
         BaseClient.cpp
         SimpleTypeStore.cpp
 )
+wf_apply_warnings(cyphesis-client)
 
 target_link_libraries(cyphesis-client PUBLIC
         cyphesis-common)

--- a/apps/cyphesis/src/client/aiclient/CMakeLists.txt
+++ b/apps/cyphesis/src/client/aiclient/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(cyphesis-cyaiclient
         PossessionClient.cpp
         PossessionAccount.cpp
 )
+wf_apply_warnings(cyphesis-cyaiclient)
 
 
 target_link_libraries(cyphesis-cyaiclient
@@ -25,6 +26,7 @@ target_link_libraries(cyphesis-cyaiclient
 
 add_executable(cyaiclient
         aiclient.cpp)
+wf_apply_warnings(cyaiclient)
 
 #If Python has been built statically (as with Conan) we need to enable exports so the dynamic loading works.
 if (PYTHON_IS_STATIC)

--- a/apps/cyphesis/src/client/cyclient/CMakeLists.txt
+++ b/apps/cyphesis/src/client/cyclient/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(cyphesis-cyclient
         Python_ClientAPI.cpp
         CyPy_CreatorClient.cpp
         CyPy_ObserverClient.cpp)
+wf_apply_warnings(cyphesis-cyclient)
 
 target_link_libraries(cyphesis-cyclient
         cyphesis-client
@@ -28,6 +29,7 @@ target_link_libraries(cyphesis-cyclient
 add_executable(cyclient
         client.cpp
 )
+wf_apply_warnings(cyclient)
 
 target_link_libraries(cyclient
         cyphesis-cyclient

--- a/apps/cyphesis/src/common/CMakeLists.txt
+++ b/apps/cyphesis/src/common/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(cyphesis-common
         AtlasFactories.cpp
         PropertyUtil.cpp
 )
+wf_apply_warnings(cyphesis-common)
 
 target_link_libraries(cyphesis-common PUBLIC
         wfmath
@@ -86,6 +87,7 @@ if (CYPHESIS_USE_POSTGRES)
 endif (CYPHESIS_USE_POSTGRES)
 
 add_library(cyphesis-db ${db_files})
+wf_apply_warnings(cyphesis-db)
 
 if (CYPHESIS_USE_POSTGRES)
     target_link_libraries(cyphesis-db PUBLIC PostgreSQL::PostgreSQL)

--- a/apps/cyphesis/src/modules/CMakeLists.txt
+++ b/apps/cyphesis/src/modules/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(cyphesis-modules
         DateTime.cpp
         WorldTime.cpp)
+wf_apply_warnings(cyphesis-modules)
 
 
 target_link_libraries(cyphesis-modules PUBLIC

--- a/apps/cyphesis/src/navigation/CMakeLists.txt
+++ b/apps/cyphesis/src/navigation/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(cyphesis-navigation
         AwarenessUtils.h
         IHeightProvider.h
 )
+wf_apply_warnings(cyphesis-navigation)
 
 target_link_libraries(cyphesis-navigation PUBLIC
         cyphesis-rulesai

--- a/apps/cyphesis/src/physics/CMakeLists.txt
+++ b/apps/cyphesis/src/physics/CMakeLists.txt
@@ -8,8 +8,9 @@ add_library(cyphesis-physics
         Transform.cpp
         Convert.h
         Course_impl.h
-        Shape_impl.h
+         Shape_impl.h
 )
+wf_apply_warnings(cyphesis-physics)
 
 target_link_libraries(cyphesis-physics PUBLIC
         wfmath

--- a/apps/cyphesis/src/pythonbase/CMakeLists.txt
+++ b/apps/cyphesis/src/pythonbase/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(cyphesis-pythonbase
         WrapperBase.cpp
         PythonMalloc.cpp
         PythonDebug.cpp)
+wf_apply_warnings(cyphesis-pythonbase)
 
 target_link_libraries(cyphesis-pythonbase PUBLIC
         cyphesis-common

--- a/apps/cyphesis/src/rules/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(cyphesis-rulesbase
         Modifier.cpp
 )
+wf_apply_warnings(cyphesis-rulesbase)
 
 target_link_libraries(cyphesis-rulesbase PUBLIC
         cyphesis-common

--- a/apps/cyphesis/src/rules/ai/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/ai/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(cyphesis-rulesai
         SharedTerrain.cpp
         TypeResolver.cpp
 )
+wf_apply_warnings(cyphesis-rulesai)
 
 target_link_libraries(cyphesis-rulesai PUBLIC
         external-remotery

--- a/apps/cyphesis/src/rules/ai/python/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/ai/python/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(cyphesis-rulesai_python
         CyPy_Ai.cpp
         CyPy_Steering.cpp
         CyPy_MemEntity.cpp)
+wf_apply_warnings(cyphesis-rulesai_python)
 
 target_link_libraries(cyphesis-rulesai_python PUBLIC
         cyphesis-rulesai

--- a/apps/cyphesis/src/rules/python/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/python/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(cyphesis-atlas_python
         CyPy_Oplist.cpp
         CyPy_Root.cpp
 )
+wf_apply_warnings(cyphesis-atlas_python)
 
 target_link_libraries(cyphesis-atlas_python PUBLIC
         cyphesis-pythonbase
@@ -25,6 +26,7 @@ add_library(cyphesis-physics_python
         CyPy_Physics.cpp
         CyPy_Ball.cpp
 )
+wf_apply_warnings(cyphesis-physics_python)
 
 target_link_libraries(cyphesis-physics_python PUBLIC
         cyphesis-atlas_python
@@ -36,6 +38,7 @@ target_link_libraries(cyphesis-physics_python PUBLIC
 add_library(cyphesis-common_python
         CyPy_Common.cpp
 )
+wf_apply_warnings(cyphesis-common_python)
 
 target_link_libraries(cyphesis-common_python PUBLIC
         cyphesis-physics_python

--- a/apps/cyphesis/src/rules/simulation/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/simulation/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(cyphesis-rulessimulation
         PropertyBase.cpp
         WorldProperty.cpp
 )
+wf_apply_warnings(cyphesis-rulessimulation)
 
 target_link_libraries(cyphesis-rulessimulation PUBLIC
         cyphesis-external-pycxx

--- a/apps/cyphesis/src/rules/simulation/python/CMakeLists.txt
+++ b/apps/cyphesis/src/rules/simulation/python/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(cyphesis-rulessimulation_python
         CyPy_Domain.cpp
         CyPy_LocatedEntity.cpp
 )
+wf_apply_warnings(cyphesis-rulessimulation_python)
 
 target_link_libraries(cyphesis-rulessimulation_python PUBLIC
         cyphesis-rulessimulation

--- a/apps/cyphesis/src/server/CMakeLists.txt
+++ b/apps/cyphesis/src/server/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(cyphesis-comm
         CommMDNSPublisher.cpp
         IdleConnector.cpp
 )
+wf_apply_warnings(cyphesis-comm)
 
 target_link_libraries(cyphesis-comm PUBLIC
         cyphesis-common
@@ -61,6 +62,7 @@ set(server_files
 
 add_library(cyphesis-server
         ${server_files})
+wf_apply_warnings(cyphesis-server)
 
 target_link_libraries(cyphesis-server PUBLIC
         cyphesis-common
@@ -72,6 +74,7 @@ target_link_libraries(cyphesis-server PUBLIC
 add_executable(cyphesis
         server.cpp
 )
+wf_apply_warnings(cyphesis)
 
 #If Python has been built statically (as with Conan) we need to enable exports so the dynamic loading works.
 if (PYTHON_IS_STATIC)

--- a/apps/cyphesis/src/tools/CMakeLists.txt
+++ b/apps/cyphesis/src/tools/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(cycmd
         JunctureContext.cpp
         Interactive.cpp
 )
+wf_apply_warnings(cycmd)
 
 target_link_libraries(cycmd PUBLIC
         cyphesis-common
@@ -23,6 +24,7 @@ target_link_libraries(cycmd PUBLIC
 install(TARGETS cycmd DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 
 add_executable(cyconfig cyconfig.cpp)
+wf_apply_warnings(cyconfig)
 target_link_libraries(cyconfig PUBLIC
         cyphesis-common
 )
@@ -32,6 +34,7 @@ add_executable(cypasswd
         cypasswd.cpp
         DatabaseCreation.cpp
 )
+wf_apply_warnings(cypasswd)
 target_link_libraries(cypasswd PUBLIC
         cyphesis-db
         cyphesis-common
@@ -42,6 +45,7 @@ add_executable(cydb
         cydb.cpp
         DatabaseCreation.cpp
 )
+wf_apply_warnings(cydb)
 
 target_link_libraries(cydb
         readline::readline
@@ -51,6 +55,7 @@ target_link_libraries(cydb
 install(TARGETS cydb DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 
 add_executable(cypython cypython.cpp)
+wf_apply_warnings(cypython)
 target_link_libraries(cypython
         readline::readline
         cyphesis-common
@@ -64,6 +69,7 @@ add_executable(cyexport
         AgentCreationTask.cpp
         WaitForDeletionTask.cpp
 )
+wf_apply_warnings(cyexport)
 target_link_libraries(cyexport PUBLIC
         cyphesis-common
 )
@@ -77,6 +83,7 @@ add_executable(cyimport
         EntityTraversalTask.cpp
         WaitForDeletionTask.cpp
 )
+wf_apply_warnings(cyimport)
 target_link_libraries(cyimport
         cyphesis-common)
 install(TARGETS cyimport DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})

--- a/apps/cyphesis/tests/CMakeLists.txt
+++ b/apps/cyphesis/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(PYTHON_TESTS_LIBS
 macro(wf_add_test TEST_FILE)
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
     add_executable(${TEST_NAME} ${TEST_FILE} ../src/common/debug.cpp TestWorld.cpp ${ARGN})
+    wf_apply_warnings(${TEST_NAME})
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
     target_compile_definitions(${TEST_NAME} PUBLIC TESTDATADIR=\"${CMAKE_CURRENT_SOURCE_DIR}/data\")
@@ -110,6 +111,7 @@ endmacro()
 macro(wf_add_benchmark TEST_FILE)
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
     add_executable(${TEST_NAME} ${TEST_FILE} ../src/common/debug.cpp TestWorld.cpp ${ARGN})
+    wf_apply_warnings(${TEST_NAME})
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 
     add_dependencies(benchmark ${TEST_NAME})

--- a/apps/cyphesis/tools/pythondocsgenerator/CMakeLists.txt
+++ b/apps/cyphesis/tools/pythondocsgenerator/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(cyphesis-pythondocgenerator
         PythonDocGenerator.cpp)
+wf_apply_warnings(cyphesis-pythondocgenerator)
 
 target_link_options(cyphesis-pythondocgenerator PUBLIC "LINKER:-z,muldefs")
 

--- a/apps/ember/CMakeLists.txt
+++ b/apps/ember/CMakeLists.txt
@@ -27,7 +27,7 @@ endif ()
 macro(wf_add_plugin _LIB_NAME _SOURCE_FILES)
 
     add_library(${_LIB_NAME} MODULE ${_SOURCE_FILES})
-    target_compile_options(${_LIB_NAME} PRIVATE ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
 
     install(TARGETS ${_LIB_NAME}
             ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/ember/widgets

--- a/apps/ember/src/components/assets/CMakeLists.txt
+++ b/apps/ember/src/components/assets/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ember-assets
         AssetsUpdater.cpp
 )
+wf_apply_warnings(ember-assets)
 
 target_link_libraries(ember-assets PUBLIC
         squallcore

--- a/apps/ember/src/components/cegui/CMakeLists.txt
+++ b/apps/ember/src/components/cegui/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(ember-cegui STATIC
         SDLNativeClipboardProvider.cpp
         CEGUISetup.cpp
 )
+wf_apply_warnings(ember-cegui)
 
 target_link_libraries(ember-cegui PUBLIC
         ember-services
@@ -19,6 +20,7 @@ file(GLOB CEGUI_FILES bindings/lua/*.cpp)
 add_library(ember-BindingsCEGUI STATIC
         ${CEGUI_FILES}
 )
+wf_apply_warnings(ember-BindingsCEGUI)
 
 target_link_libraries(ember-BindingsCEGUI PUBLIC
         ember-framework

--- a/apps/ember/src/components/entitymapping/CMakeLists.txt
+++ b/apps/ember/src/components/entitymapping/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(ember-entitymapping STATIC
         Matches/SingleAttributeMatch.cpp
         Matches/SingleAttributeMatch.h
 )
+wf_apply_warnings(ember-entitymapping)
 
 target_link_libraries(ember-entitymapping PUBLIC
         wfmath

--- a/apps/ember/src/components/lua/CMakeLists.txt
+++ b/apps/ember/src/components/lua/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ember-lua-console STATIC
         LuaConsoleObject.cpp
 )
+wf_apply_warnings(ember-lua-console)
 target_link_libraries(ember-lua-console PUBLIC
         ember-framework
         ember-external-sol2
@@ -12,6 +13,7 @@ add_subdirectory(bindings)
 add_library(ember-lua_component STATIC
         LuaScriptingProvider.cpp
 )
+wf_apply_warnings(ember-lua_component)
 
 
 target_link_libraries(ember-lua_component PUBLIC

--- a/apps/ember/src/components/lua/bindings/lua/CMakeLists.txt
+++ b/apps/ember/src/components/lua/bindings/lua/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ember-BindingsLua STATIC
         BindingsLua.cpp)
+wf_apply_warnings(ember-BindingsLua)
 
 target_link_libraries(ember-BindingsLua PUBLIC
         ember-lua-console

--- a/apps/ember/src/components/navigation/CMakeLists.txt
+++ b/apps/ember/src/components/navigation/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(ember-navigation STATIC
         Steering.cpp
         Loitering.cpp
         AwarenessUtils.h)
+wf_apply_warnings(ember-navigation)
 
 target_link_libraries(ember-navigation PUBLIC
         external-Detour

--- a/apps/ember/src/components/ogre/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/CMakeLists.txt
@@ -163,11 +163,13 @@ add_library(ember-ogre STATIC
         FrameListener.cpp
         SquallArchive.cpp
 )
+wf_apply_warnings(ember-ogre)
 
 add_library(ember-ogre-support STATIC
         XMLHelper.cpp
         OgreInfo.cpp
 )
+wf_apply_warnings(ember-ogre-support)
 target_include_directories(ember-ogre-support PUBLIC .)
 target_link_libraries(ember-ogre-support PUBLIC
         ember-framework

--- a/apps/ember/src/components/ogre/lod/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/lod/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ember-ogre-lod STATIC
         ClusterLodStrategy.cpp
 
 )
+wf_apply_warnings(ember-ogre-lod)
 
 target_link_libraries(ember-ogre-lod PUBLIC
         ember-framework

--- a/apps/ember/src/components/ogre/mapping/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/mapping/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(ember-ogre-mapping STATIC
         ModelActionCreator.cpp
         XMLEntityMappingDefinitionSerializer.cpp
 )
+wf_apply_warnings(ember-ogre-mapping)
 
 target_link_libraries(ember-ogre-mapping PUBLIC
         ember-ogre-support

--- a/apps/ember/src/components/ogre/scripting/bindings/lua/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/scripting/bindings/lua/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB BINDINGS_FILES *.cpp)
 add_library(ember-BindingsEmberOgre STATIC
         ${BINDINGS_FILES}
         helpers/OgreUtils.cpp)
+wf_apply_warnings(ember-BindingsEmberOgre)
 
 target_link_libraries(ember-BindingsEmberOgre PUBLIC
         ember-ogre

--- a/apps/ember/src/components/ogre/scripting/bindings/lua/ogre/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/scripting/bindings/lua/ogre/CMakeLists.txt
@@ -3,6 +3,7 @@ file(GLOB BINDINGS_FILES *.cpp)
 add_library(ember-BindingsOgre STATIC
         ${BINDINGS_FILES}
 )
+wf_apply_warnings(ember-BindingsOgre)
 target_link_libraries(ember-BindingsOgre PUBLIC
         ember-framework
         ember-external-sol2

--- a/apps/ember/src/components/ogre/terrain/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/terrain/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(ember-ogre_terrain STATIC
         techniques/OnePixelMaterialGenerator.cpp
         TerrainModTranslator.cpp
 )
+wf_apply_warnings(ember-ogre_terrain)
 
 target_precompile_headers(ember-ogre_terrain
         REUSE_FROM

--- a/apps/ember/src/components/ogre/widgets/CMakeLists.txt
+++ b/apps/ember/src/components/ogre/widgets/CMakeLists.txt
@@ -86,6 +86,7 @@ add_library(ember-widgets STATIC
         ContainerView.cpp
         ${STATIC_WIDGETS}
 )
+wf_apply_warnings(ember-widgets)
 
 target_precompile_headers(ember-widgets
         REUSE_FROM
@@ -134,6 +135,7 @@ install(FILES ${LUA_FILES} DESTINATION ${CMAKE_INSTALL_FULL_DATADIR}/ember/scrip
 add_library(ember-BindingsAtlasAdapters STATIC
         adapters/atlas/bindings/lua/BindingsAtlasAdapters.cpp
 )
+wf_apply_warnings(ember-BindingsAtlasAdapters)
 
 target_link_libraries(ember-BindingsAtlasAdapters PUBLIC
         ember-framework
@@ -155,6 +157,7 @@ add_library(ember-BindingsRepresentations STATIC
         representations/LayoutHelper.cpp
         representations/bindings/lua/BindingsRepresentations.cpp
 )
+wf_apply_warnings(ember-BindingsRepresentations)
 
 target_link_libraries(ember-BindingsRepresentations PUBLIC
         ember-framework

--- a/apps/ember/src/domain/CMakeLists.txt
+++ b/apps/ember/src/domain/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(ember-domain
         EntityTalk.cpp
         EmberEntityRef.cpp
 )
+wf_apply_warnings(ember-domain)
 
 target_link_libraries(ember-domain PUBLIC
         eris
@@ -12,6 +13,7 @@ target_link_libraries(ember-domain PUBLIC
 add_library(ember-BindingsDomain STATIC
         bindings/lua/BindingsDomain.cpp
 )
+wf_apply_warnings(ember-BindingsDomain)
 
 target_link_libraries(ember-BindingsDomain PUBLIC
         ember-domain

--- a/apps/ember/src/framework/CMakeLists.txt
+++ b/apps/ember/src/framework/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(ember-framework STATIC
         LogExtensions.cpp
         Log.cpp
 )
+wf_apply_warnings(ember-framework)
 
 #Check for libunwind, which is optional and if present will allow for the StackChecker feature to be enabled.
 #This allows for a developer to get some insight into why some frames take too long.

--- a/apps/ember/src/framework/bindings/lua/CMakeLists.txt
+++ b/apps/ember/src/framework/bindings/lua/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(wfmath)
 add_library(ember-BindingsFramework STATIC
         BindingsFramework.cpp
 )
+wf_apply_warnings(ember-BindingsFramework)
 target_link_libraries(ember-BindingsFramework PUBLIC
         ember-framework
         ember-external-sol2

--- a/apps/ember/src/framework/bindings/lua/atlas/CMakeLists.txt
+++ b/apps/ember/src/framework/bindings/lua/atlas/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ember-BindingsAtlas STATIC
         BindingsAtlas.cpp
 )
+wf_apply_warnings(ember-BindingsAtlas)
 
 target_link_libraries(ember-BindingsAtlas PUBLIC
         ember-framework

--- a/apps/ember/src/framework/bindings/lua/eris/CMakeLists.txt
+++ b/apps/ember/src/framework/bindings/lua/eris/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB BINDINGS_FILES *.cpp)
 
 add_library(ember-BindingsEris STATIC
         ${BINDINGS_FILES})
+wf_apply_warnings(ember-BindingsEris)
 
 target_link_libraries(ember-BindingsEris PUBLIC
         ember-framework

--- a/apps/ember/src/framework/bindings/lua/varconf/CMakeLists.txt
+++ b/apps/ember/src/framework/bindings/lua/varconf/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ember-BindingsVarconf STATIC
         BindingsVarconf.cpp
 )
+wf_apply_warnings(ember-BindingsVarconf)
 
 target_link_libraries(ember-BindingsVarconf PUBLIC
         ember-framework

--- a/apps/ember/src/framework/bindings/lua/wfmath/CMakeLists.txt
+++ b/apps/ember/src/framework/bindings/lua/wfmath/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(ember-BindingsWFMath STATIC
         BindingsWFMath.cpp)
+wf_apply_warnings(ember-BindingsWFMath)
 target_link_libraries(ember-BindingsWFMath PUBLIC
         ember-framework
         ember-external-sol2

--- a/apps/ember/src/main/CMakeLists.txt
+++ b/apps/ember/src/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 #Use WIN32 to specify that on Windows it should be a non-console app.
 add_executable(ember WIN32)
+wf_apply_warnings(ember)
 target_compile_features(ember PUBLIC cxx_std_20)
 target_sources(ember PUBLIC
         Application.cpp
@@ -42,6 +43,7 @@ set(ember-libraries
 
 if (WF_USE_WIDGET_PLUGINS)
     add_library(ember-shared SHARED)
+    wf_apply_warnings(ember-shared)
     target_link_libraries(ember-shared
             ${ember-libraries}
     )

--- a/apps/ember/src/services/CMakeLists.txt
+++ b/apps/ember/src/services/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(ember-services STATIC
         sound/SoundService.cpp
         sound/SoundSource.cpp
         EmberServices.cpp)
+wf_apply_warnings(ember-services)
 
 target_link_libraries(ember-services PUBLIC
         ember-framework
@@ -50,6 +51,7 @@ file(GLOB BINDINGS_FILES bindings/lua/*.cpp)
 add_library(ember-BindingsServices STATIC
         ${BINDINGS_FILES}
 )
+wf_apply_warnings(ember-BindingsServices)
 target_link_libraries(ember-BindingsServices PUBLIC
         ember-services
         ember-external-sol2

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ if (TARGET cppunit::cppunit)
             $<TARGET_OBJECTS:ember-DetourTileCache>
             $<TARGET_OBJECTS:ember-Detour>
             $<TARGET_OBJECTS:ember-Recast>)
+    wf_apply_warnings(TestOgreView)
     target_compile_definitions(TestOgreView PUBLIC -DLOG_TASKS)
     target_link_libraries(TestOgreView cppunit::cppunit
             Bullet::Bullet
@@ -38,6 +39,7 @@ if (TARGET cppunit::cppunit)
             TestTasks.cpp
             $<TARGET_OBJECTS:ember-framework>
             $<TARGET_OBJECTS:ember-tinyxml>)
+    wf_apply_warnings(TestTasks)
     target_compile_definitions(TestTasks PUBLIC -DLOG_TASKS)
     target_link_libraries(TestTasks
             cppunit::cppunit
@@ -50,6 +52,7 @@ if (TARGET cppunit::cppunit)
             TestTimeFrame.cpp
             $<TARGET_OBJECTS:ember-framework>
             $<TARGET_OBJECTS:ember-tinyxml>)
+    wf_apply_warnings(TestTimeFrame)
     target_compile_definitions(TestTimeFrame PUBLIC -DLOG_TASKS)
     target_link_libraries(TestTimeFrame
             cppunit::cppunit
@@ -61,6 +64,7 @@ if (TARGET cppunit::cppunit)
             TestFramework.cpp
             $<TARGET_OBJECTS:ember-framework>
             $<TARGET_OBJECTS:ember-tinyxml>)
+    wf_apply_warnings(TestFramework)
     target_compile_definitions(TestFramework PUBLIC -DLOG_TASKS)
     configure_file(atlas.xml atlas.xml COPYONLY)
     target_link_libraries(TestFramework
@@ -74,6 +78,7 @@ if (TARGET cppunit::cppunit)
             TestConsoleBackend.cpp
             $<TARGET_OBJECTS:ember-framework>
             $<TARGET_OBJECTS:ember-tinyxml>)
+    wf_apply_warnings(TestConsoleBackend)
     target_compile_definitions(TestConsoleBackend PUBLIC -DLOG_TASKS)
     target_link_libraries(TestConsoleBackend
             cppunit::cppunit
@@ -83,6 +88,7 @@ if (TARGET cppunit::cppunit)
 
     add_executable(TestEmberServices
             TestEmberServices.cpp)
+    wf_apply_warnings(TestEmberServices)
     target_compile_definitions(TestEmberServices PUBLIC -DLOG_TASKS)
     target_link_libraries(TestEmberServices
             cppunit::cppunit
@@ -106,6 +112,7 @@ add_executable(ServerSettingsTest
         ../src/services/serversettings/ServerSettings.cpp
         ../src/services/serversettings/ServerSettingsCredentials.cpp
         ../src/services/config/ConfigService.cpp)
+wf_apply_warnings(ServerSettingsTest)
 target_include_directories(ServerSettingsTest PRIVATE ../src)
 target_link_libraries(ServerSettingsTest Catch2::Catch2WithMain varconf)
 add_test(NAME ServerSettingsTest COMMAND ServerSettingsTest)

--- a/apps/metaserver/src/api/CMakeLists.txt
+++ b/apps/metaserver/src/api/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(metaserver-api
         MetaServerPacket.cpp
 )
+wf_apply_warnings(metaserver-api)
 
 target_include_directories(metaserver-api PUBLIC .)
 

--- a/apps/metaserver/src/server/CMakeLists.txt
+++ b/apps/metaserver/src/server/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(metaserver
         MetaServerHandlerUDP.cpp
         DataObject.cpp
 )
+wf_apply_warnings(metaserver)
 target_link_libraries(metaserver
         metaserver-api
         Boost::program_options
@@ -17,6 +18,7 @@ install(TARGETS metaserver DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 add_executable(ms-testserver
         TestServer.cpp
 )
+wf_apply_warnings(ms-testserver)
 target_link_libraries(ms-testserver
         metaserver-api
         Boost::program_options
@@ -27,6 +29,7 @@ target_link_libraries(ms-testserver
 add_executable(ms-testclient
         TestClient.cpp
 )
+wf_apply_warnings(ms-testclient)
 target_link_libraries(ms-testclient
         metaserver-api
         Boost::program_options
@@ -37,6 +40,7 @@ target_link_libraries(ms-testclient
 add_executable(ms-pdnspipe
         PDNSPipe.cpp
 )
+wf_apply_warnings(ms-pdnspipe)
 target_link_libraries(ms-pdnspipe
         metaserver-api
         Boost::program_options

--- a/apps/metaserver/tests/CMakeLists.txt
+++ b/apps/metaserver/tests/CMakeLists.txt
@@ -4,11 +4,12 @@ if (BUILD_METASERVER_SERVER)
 
     wf_find_boost(program_options)
 
-    add_executable(MetaServer_unittest
-            MetaServer_unittest.cpp
-            ../src/server/MetaServer.cpp
-            ../src/api/MetaServerPacket.cpp
-            ../src/server/DataObject.cpp)
+      add_executable(MetaServer_unittest
+              MetaServer_unittest.cpp
+              ../src/server/MetaServer.cpp
+              ../src/api/MetaServerPacket.cpp
+              ../src/server/DataObject.cpp)
+      wf_apply_warnings(MetaServer_unittest)
     target_link_libraries(MetaServer_unittest PUBLIC
             cppunit::cppunit
             Boost::program_options
@@ -18,9 +19,10 @@ if (BUILD_METASERVER_SERVER)
     add_dependencies(check MetaServer_unittest)
 
 
-    add_executable(MetaServerPackage_unittest
-            MetaServerPacket_unittest.cpp
-            ../src/api/MetaServerPacket.cpp)
+      add_executable(MetaServerPackage_unittest
+              MetaServerPacket_unittest.cpp
+              ../src/api/MetaServerPacket.cpp)
+      wf_apply_warnings(MetaServerPackage_unittest)
     target_link_libraries(MetaServerPackage_unittest PUBLIC
             cppunit::cppunit
             Boost::program_options
@@ -30,9 +32,10 @@ if (BUILD_METASERVER_SERVER)
     add_dependencies(check MetaServerPackage_unittest)
 
 
-    add_executable(DataObject_unittest
-            DataObject_unittest.cpp
-            ../src/server/DataObject.cpp)
+      add_executable(DataObject_unittest
+              DataObject_unittest.cpp
+              ../src/server/DataObject.cpp)
+      wf_apply_warnings(DataObject_unittest)
     target_link_libraries(DataObject_unittest PUBLIC
             cppunit::cppunit
             Boost::program_options
@@ -42,10 +45,11 @@ if (BUILD_METASERVER_SERVER)
     add_dependencies(check DataObject_unittest)
 
 
-    add_executable(MetaServerHandlerUDP_unittest
-            MetaServerHandlerUDP_unittest.cpp
-            ../src/server/MetaServerHandlerUDP.cpp
-            ../src/api/MetaServerPacket.cpp)
+      add_executable(MetaServerHandlerUDP_unittest
+              MetaServerHandlerUDP_unittest.cpp
+              ../src/server/MetaServerHandlerUDP.cpp
+              ../src/api/MetaServerPacket.cpp)
+      wf_apply_warnings(MetaServerHandlerUDP_unittest)
     target_link_libraries(MetaServerHandlerUDP_unittest PUBLIC
             cppunit::cppunit
             Boost::program_options

--- a/libs/atlas/CMakeLists.txt
+++ b/libs/atlas/CMakeLists.txt
@@ -19,8 +19,7 @@ option(ATLAS_DISABLE_BENCHMARKS "Disable benchmarks." FALSE)
 macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
-
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC

--- a/libs/atlas/src/CMakeLists.txt
+++ b/libs/atlas/src/CMakeLists.txt
@@ -137,7 +137,7 @@ if (NOT NO_LIBS_INSTALL)
     # The "atlas_convert" tool, only available on systems which provides unistd.h
     if (HAS_UNISTD)
         add_executable(atlas_convert atlas_convert.cpp)
-        target_compile_options(atlas_convert PRIVATE ${WF_WARNING_FLAGS})
+        wf_apply_warnings(atlas_convert)
         target_link_libraries(atlas_convert AtlasCodecs AtlasMessage Atlas)
 
         install(TARGETS atlas_convert

--- a/libs/eris/CMakeLists.txt
+++ b/libs/eris/CMakeLists.txt
@@ -7,8 +7,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
-
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC

--- a/libs/eris/tests/CMakeLists.txt
+++ b/libs/eris/tests/CMakeLists.txt
@@ -46,9 +46,11 @@ wf_add_test(ActiveMarker_UnitTest.cpp ../src/Eris/ActiveMarker.cpp)
 #        viewTest.cpp viewTest.h
 #        avatarTest.cpp avatarTest.h
 #        calendarTest.cpp calendarTest.h)
-if (NOT WIN32)
+    if (NOT WIN32)
     add_executable(metaQuery metaQuery.cpp)
+    wf_apply_warnings(metaQuery)
     target_link_libraries(metaQuery ${LIBNAME})
     add_executable(eris_connect connect.cpp)
+    wf_apply_warnings(eris_connect)
     target_link_libraries(eris_connect ${LIBNAME})
-endif ()
+    endif ()

--- a/libs/mercator/CMakeLists.txt
+++ b/libs/mercator/CMakeLists.txt
@@ -15,7 +15,7 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
             VERSION ${ABI_VERSION}
             SOVERSION ${SOVERSION}
     )
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC

--- a/libs/squall/CMakeLists.txt
+++ b/libs/squall/CMakeLists.txt
@@ -24,8 +24,7 @@ find_package(spdlog REQUIRED)
 macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
-
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC

--- a/libs/varconf/CMakeLists.txt
+++ b/libs/varconf/CMakeLists.txt
@@ -9,7 +9,7 @@ set(DESCRIPTION "Configuration library for the Worldforge system.")
 macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
     target_include_directories(${_LIB_NAME}
             PUBLIC

--- a/libs/wfmath/CMakeLists.txt
+++ b/libs/wfmath/CMakeLists.txt
@@ -11,7 +11,7 @@ macro(wf_add_library _LIB_NAME _SOURCE_FILES_VAR _HEADER_FILES_VAR)
 
     add_library(${_LIB_NAME} ${${_SOURCE_FILES_VAR}})
     target_compile_features(${_LIB_NAME} PUBLIC cxx_std_20)
-    target_compile_options(${_LIB_NAME} PUBLIC ${WF_WARNING_FLAGS})
+    wf_apply_warnings(${_LIB_NAME})
     target_include_directories(${_LIB_NAME}
             PUBLIC
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"

--- a/tools/nanite/tests/CMakeLists.txt
+++ b/tools/nanite/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR})
 add_executable(MeshPreprocessorTest MeshPreprocessorTest.cpp)
+wf_apply_warnings(MeshPreprocessorTest)
 add_test(NAME MeshPreprocessorTest COMMAND MeshPreprocessorTest)

--- a/tools/performance/tests/CMakeLists.txt
+++ b/tools/performance/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR})
 add_executable(ProfilerCLI ../ProfilerCLI.cpp ../../../apps/ember/src/framework/Profiler.cpp)
+wf_apply_warnings(ProfilerCLI)
 add_executable(ProfilerCLITest ProfilerCLITest.cpp ../../../apps/ember/src/framework/Profiler.cpp)
+wf_apply_warnings(ProfilerCLITest)
 add_dependencies(ProfilerCLITest ProfilerCLI)
 add_test(NAME ProfilerCLITest COMMAND ProfilerCLITest)


### PR DESCRIPTION
## Summary
- replace global compiler warning flags with `wf_apply_warnings` helper
- apply warning flags to internal targets across libs and apps

## Testing
- ❌ `cmake -S . -B build` *(missing dependencies: cppunit, spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c18e8734832d973751220a99543c