### PR TITLE
chore: require CMake 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.23)
 
 project(Worldforge)
 


### PR DESCRIPTION
## Summary
- raise cmake minimum to 3.23

## Testing
- `conan install . -s build_type=Release --output-folder=build --build missing` *(fails: Package 'cegui/0.8.7@worldforge' not resolved)*
- `cmake --preset conan-release` *(fails: Invalid preset: "coverage")*

------
https://chatgpt.com/codex/tasks/task_e_68b8c4c220dc832dbae5302c0147d236