### PR TITLE
Condition install prefix assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(PREBUILT_DIR "Directory for prebuilt artifacts" "${CMAKE_SOURCE_DIR}/prebuilt")
-set(CMAKE_INSTALL_PREFIX "${PREBUILT_DIR}" CACHE PATH "Install path prefix" FORCE)
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${PREBUILT_DIR}" CACHE PATH "Install path prefix" FORCE)
+endif ()
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     message(STATUS "Configuring 64-bit build")


### PR DESCRIPTION
## Summary
- Avoid overriding user-specified installation directory by guarding `CMAKE_INSTALL_PREFIX` assignment

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "cppunit" or "spdlog")*
- `conan install . --output-folder=build --build=missing` *(fails: Unable to find 'cegui/0.8.7@worldforge' in remotes)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c6988994832d91f62bbb2ff6495e