### PR TITLE
chore: remove using namespace std from metaserver service

### DIFF
--- a/apps/ember/src/services/metaserver/MetaserverService.cpp
+++ b/apps/ember/src/services/metaserver/MetaserverService.cpp
@@ -27,9 +27,6 @@
 
 #include "framework/Session.h"
 
-
-using namespace std;
-
 namespace Ember {
 
 MetaserverService::MetaserverService(Session& session, ConfigService& configSrv) :
@@ -59,7 +56,7 @@ MetaserverService::~MetaserverService() {
 }
 
 
-void MetaserverService::gotFailure(const string& msg) {
+void MetaserverService::gotFailure(const std::string& msg) {
 	logger->warn("Got Meta-server error: {}", msg);
 }
 


### PR DESCRIPTION
## Summary
- remove `using namespace std;` from `MetaserverService.cpp`
- qualify `string` with `std::` in `gotFailure`

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "cppunit" and "Microsoft.GSL")*


------
https://chatgpt.com/codex/tasks/task_e_68b8c6959d48832dae73a28ba2ebb128