### PR TITLE
Add safe polygon intersection dispatcher and tests for unknown shapes

### DIFF
--- a/libs/wfmath/src/wfmath/intersect.h
+++ b/libs/wfmath/src/wfmath/intersect.h
@@ -27,13 +27,21 @@
 #include <wfmath/vector.h>
 #include <wfmath/point.h>
 #include <wfmath/const.h>
+#include <cmath>
+
+namespace WFMath {
+template<int dim> class AxisBox;
+template<int dim> class Ball;
+template<int dim> class Segment;
+template<int dim> class RotBox;
+template<int dim> class Polygon;
+}
+
 #include <wfmath/intersect_decls.h>
 #include <wfmath/axisbox.h>
 #include <wfmath/ball.h>
 #include <wfmath/segment.h>
 #include <wfmath/rotbox.h>
-
-#include <cmath>
 
 namespace WFMath {
 
@@ -534,6 +542,43 @@ template<int dim>
 struct IntersectDispatcher<Segment<dim>, RotBox<dim>> {
         static bool apply(const Segment<dim>& s, const RotBox<dim>& r, bool proper) {
                 return WFMath::Intersect(r, s, proper);
+        }
+};
+
+// Polygon<> combinations
+
+template<int dim>
+struct IntersectDispatcher<Point<dim>, Polygon<dim>> {
+        static bool apply(const Point<dim>& p, const Polygon<dim>& poly, bool proper) {
+                return WFMath::Intersect(poly, p, proper);
+        }
+};
+
+template<int dim>
+struct IntersectDispatcher<AxisBox<dim>, Polygon<dim>> {
+        static bool apply(const AxisBox<dim>& box, const Polygon<dim>& poly, bool proper) {
+                return WFMath::Intersect(poly, box, proper);
+        }
+};
+
+template<int dim>
+struct IntersectDispatcher<Ball<dim>, Polygon<dim>> {
+        static bool apply(const Ball<dim>& b, const Polygon<dim>& poly, bool proper) {
+                return WFMath::Intersect(poly, b, proper);
+        }
+};
+
+template<int dim>
+struct IntersectDispatcher<Segment<dim>, Polygon<dim>> {
+        static bool apply(const Segment<dim>& s, const Polygon<dim>& poly, bool proper) {
+                return WFMath::Intersect(poly, s, proper);
+        }
+};
+
+template<int dim>
+struct IntersectDispatcher<RotBox<dim>, Polygon<dim>> {
+        static bool apply(const RotBox<dim>& r, const Polygon<dim>& poly, bool proper) {
+                return WFMath::Intersect(poly, r, proper);
         }
 };
 

--- a/libs/wfmath/tests/intersect_unknown_test.cpp
+++ b/libs/wfmath/tests/intersect_unknown_test.cpp
@@ -3,6 +3,8 @@
 #include "wfmath/point_funcs.h"
 #include "wfmath/axisbox.h"
 #include "wfmath/axisbox_funcs.h"
+#include "wfmath/polygon.h"
+#include "wfmath/polygon_intersect.h"
 #include <assert.h>
 
 using namespace WFMath;
@@ -18,11 +20,24 @@ int main()
     assert(Intersect(box, p, false));
     assert(Intersect(p, box, false));
 
+    // Polygon combinations are implemented only with the polygon first
+    Polygon<2> poly;
+    poly.addCorner(0, p);
+    poly.addCorner(0, Point<2>(1, 0));
+    poly.addCorner(0, Point<2>(1, -1));
+    poly.addCorner(0, Point<2>(0, -1));
+    poly.isValid();
+    assert(Intersect(poly, box, false));
+    assert(Intersect(box, poly, false));
+
     // Completely unknown combinations should be safely handled
     DummyA a;
     DummyB b;
     assert(!Intersect(a, b, false));
     assert(!Intersect(b, a, true));
     assert(!Intersect(a, a, false));
+    // Mixed known/unknown combinations
+    assert(!Intersect(a, box, false));
+    assert(!Intersect(box, a, true));
     return 0;
 }


### PR DESCRIPTION
## Summary
- Ensure all WFMath shapes have forward declarations
- Add dispatchers so reversed polygon intersections delegate to existing overloads
- Expand unit tests to cover polygon reversing and mixed unknown combinations

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Microsoft.GSL")*
- `g++ -std=c++17 libs/wfmath/tests/intersect_unknown_test.cpp ...` *(fails: undefined reference to `WFMath::Equal` and other symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c82f6634832da5c415bb8c672161