### PR TITLE
Expose barycenter helpers and add tests

### DIFF
--- a/libs/wfmath/src/wfmath/point.h
+++ b/libs/wfmath/src/wfmath/point.h
@@ -233,12 +233,19 @@ public:
 	/// Access the i'th coordinate of the point
 	CoordType& operator[](const int i) { return m_elem[i]; }
 
-	/// Get the square of the distance from p1 to p2
-	friend CoordType SquaredDistance<dim>(const Point& p1, const Point& p2);
+        /// Get the square of the distance from p1 to p2
+        friend CoordType SquaredDistance<dim>(const Point& p1, const Point& p2);
 
-// FIXME instatiation problem when declared as friend
-//  template<template<class> class container>
-//  friend Point Barycenter(const container<Point>& c);
+        /// Allow Barycenter helper functions access to private members
+        template<int d, template<class, class> class container>
+        friend Point<d> Barycenter(
+                const container<Point<d>, std::allocator<Point<d>>>& c);
+
+        template<int d, template<class, class> class container,
+                 template<class, class> class container2>
+        friend Point<d> Barycenter(
+                const container<Point<d>, std::allocator<Point<d>>>& c,
+                const container2<CoordType, std::allocator<CoordType>>& weights);
 
 	/// Find a point on the line containing p1 and p2, by default the midpoint
 	/**

--- a/libs/wfmath/tests/CMakeLists.txt
+++ b/libs/wfmath/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ wf_add_test(shape_test.cpp)
 wf_add_test(timestamp_test.cpp)
 wf_add_test(vector_test.cpp)
 wf_add_test(intersect_unknown_test.cpp)
+wf_add_test(barycenter_test.cpp)
 
 if (Atlas_FOUND)
     link_directories(${Atlas_LIBRARY_DIR})

--- a/libs/wfmath/tests/barycenter_test.cpp
+++ b/libs/wfmath/tests/barycenter_test.cpp
@@ -1,0 +1,23 @@
+#include "wfmath/point.h"
+#include "wfmath/point_funcs.h"
+
+#include <vector>
+#include <list>
+#include <cassert>
+
+using namespace WFMath;
+
+int main() {
+    // Unweighted barycenter of three 2D points
+    std::vector<Point<2>> pts2 = {Point<2>(0, 0), Point<2>(6, 0), Point<2>(0, 6)};
+    Point<2> bc2 = Barycenter(pts2);
+    assert(bc2.isEqualTo(Point<2>(2, 2)));
+
+    // Weighted barycenter of three 3D points
+    std::vector<Point<3>> pts3 = {Point<3>(0, 0, 0), Point<3>(3, 3, 3), Point<3>(6, 0, 0)};
+    std::list<CoordType> weights = {1, 2, 3};
+    Point<3> bc3 = Barycenter(pts3, weights);
+    assert(bc3.isEqualTo(Point<3>(4, 1, 1)));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- allow templated Barycenter helpers to access Point internals
- add dedicated barycenter test and wire into CMake

## Testing
- `g++ -std=c++20 -I src tests/barycenter_test.cpp src/wfmath/const.cpp -o tests/barycenter_test -v`
- `./tests/barycenter_test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e78533dc832d954fb331834d886c