### PR TITLE
Use communicate for client process in minimal_session e2e test

### DIFF
--- a/apps/tests/e2e/minimal_session.py
+++ b/apps/tests/e2e/minimal_session.py
@@ -130,10 +130,14 @@ def main() -> int:
         text=True,
     )
     processes.append(client)
-    client.wait(timeout=60)
-    output = client.stdout.read() if client.stdout else ""
+    try:
+        stdout, _ = client.communicate(timeout=60)
+    except subprocess.TimeoutExpired:
+        client.kill()
+        stdout, _ = client.communicate()
+        raise
 
-    if "Connected" not in output and client.returncode != 0:
+    if "Connected" not in stdout and client.returncode != 0:
         raise RuntimeError("ember failed to connect to cyphesis")
 
     print("E2E session completed")


### PR DESCRIPTION
## Summary
- capture ember client output using `communicate` with a timeout
- terminate the client process on timeout and check connection via captured output

## Testing
- `python -m py_compile apps/tests/e2e/minimal_session.py`
- `pytest apps/tests/e2e/minimal_session.py -q` *(no tests ran)*
- `python apps/tests/e2e/minimal_session.py` *(Build preset not found; skipping e2e test)*

------
https://chatgpt.com/codex/tasks/task_e_68b90957d188832db80964763789913c