### PR TITLE
refactor: mock bow dependencies with fixtures

### DIFF
--- a/apps/tests/e2e/_stubs.py
+++ b/apps/tests/e2e/_stubs.py
@@ -1,0 +1,59 @@
+import math
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+
+@dataclass
+class Operation:
+    name: str
+    entity: object | None = None
+    to: str | None = None
+    from_: str | None = None
+
+
+class Entity(dict):
+    def __init__(self, id: str | None = None, **kwargs):
+        super().__init__(**kwargs)
+        if id is not None:
+            self["id"] = id
+        self.id = id
+
+
+class Oplist(list):
+    """Simple list subclass used for operations."""
+    pass
+
+
+@dataclass
+class Vector3D:
+    x: float = 0
+    y: float = 0
+    z: float = 0
+
+    def __init__(self, x: float = 0, y: float = 0, z: float = 0):
+        if isinstance(x, Vector3D):
+            self.x, self.y, self.z = x.x, x.y, x.z
+        else:
+            self.x, self.y, self.z = x, y, z
+
+    def normalize(self) -> "Vector3D":
+        mag = math.sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
+        if mag:
+            self.x /= mag
+            self.y /= mag
+            self.z /= mag
+        return self
+
+    def __mul__(self, other: float) -> "Vector3D":
+        return Vector3D(self.x * other, self.y * other, self.z * other)
+
+    def __iadd__(self, other: "Vector3D") -> "Vector3D":
+        self.x += other.x
+        self.y += other.y
+        self.z += other.z
+        return self
+
+
+class Quaternion:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/apps/tests/e2e/conftest.py
+++ b/apps/tests/e2e/conftest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _stubs import Operation, Entity, Oplist, Vector3D, Quaternion
+
+
+@pytest.fixture
+def operation() -> type[Operation]:
+    return Operation
+
+
+@pytest.fixture
+def entity() -> type[Entity]:
+    return Entity
+
+
+@pytest.fixture
+def vector3d() -> type[Vector3D]:
+    return Vector3D
+
+
+class _StoppableTask:
+    def __init__(self, usage, **kwargs):
+        self.usage = usage
+        self.usages = [{"name": "stop"}]
+
+    def start_action(self, name, duration=None):
+        return self.usage.actor.start_action(name, duration)
+
+    def irrelevant(self, *args):
+        return None
+
+
+class _Usage:
+    @staticmethod
+    def set_cooldown_on_attached(tool, actor):
+        pass
+
+    @staticmethod
+    def delay_task_if_needed(task):
+        return task
+
+
+@pytest.fixture
+def bow_module(monkeypatch, operation, entity, vector3d):
+    atlas = SimpleNamespace(Operation=operation, Entity=entity, Oplist=Oplist)
+    physics = SimpleNamespace(Vector3D=vector3d, Quaternion=Quaternion)
+    entity_filter = SimpleNamespace(Filter=lambda expr: SimpleNamespace(expr=expr))
+    server = SimpleNamespace(OPERATION_BLOCKED="blocked")
+
+    monkeypatch.setitem(sys.modules, "atlas", atlas)
+    monkeypatch.setitem(sys.modules, "physics", physics)
+    monkeypatch.setitem(sys.modules, "entity_filter", entity_filter)
+    monkeypatch.setitem(sys.modules, "server", server)
+    monkeypatch.setitem(sys.modules, "world", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "world.StoppableTask", SimpleNamespace(StoppableTask=_StoppableTask))
+    monkeypatch.setitem(sys.modules, "world.utils", SimpleNamespace(Usage=_Usage))
+
+    root = Path(__file__).resolve().parents[3]
+    bow_path = root / "apps/cyphesis/data/rulesets/deeds/scripts/world/objects/tools/Bow.py"
+    spec = importlib.util.spec_from_file_location("Bow", bow_path)
+    Bow = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(Bow)
+    return Bow

--- a/apps/tests/e2e/test_bow_animation.py
+++ b/apps/tests/e2e/test_bow_animation.py
@@ -1,163 +1,68 @@
-import importlib.util
-import math
 import types
-import sys
-from pathlib import Path
-
-# --- stub modules ---
-
-class Operation:
-    def __init__(self, name, entity=None, *, to=None, from_=None):
-        self.name = name
-        self.entity = entity
-        self.to = to
-        self.from_ = from_
-
-class Entity(dict):
-    def __init__(self, id=None, **kwargs):
-        super().__init__(**kwargs)
-        if id is not None:
-            self["id"] = id
-        self.id = id
-
-class Oplist(list):
-    def append(self, obj):
-        super().append(obj)
-
-atlas = types.ModuleType("atlas")
-atlas.Operation = Operation
-atlas.Entity = Entity
-atlas.Oplist = Oplist
-sys.modules["atlas"] = atlas
-
-class Vector3D:
-    def __init__(self, x=0, y=0, z=0):
-        if isinstance(x, Vector3D):
-            self.x, self.y, self.z = x.x, x.y, x.z
-        else:
-            self.x, self.y, self.z = x, y, z
-    def normalize(self):
-        mag = math.sqrt(self.x**2 + self.y**2 + self.z**2)
-        if mag:
-            self.x/=mag; self.y/=mag; self.z/=mag
-        return self
-    def __mul__(self, other):
-        return Vector3D(self.x * other, self.y * other, self.z * other)
-    def __iadd__(self, other):
-        self.x += other.x; self.y += other.y; self.z += other.z
-        return self
-
-class Quaternion:
-    def __init__(self, *args, **kwargs):
-        pass
-
-physics = types.ModuleType("physics")
-physics.Vector3D = Vector3D
-physics.Quaternion = Quaternion
-sys.modules["physics"] = physics
-
-entity_filter = types.ModuleType("entity_filter")
-class Filter:
-    def __init__(self, expr):
-        self.expr = expr
-entity_filter.Filter = Filter
-sys.modules["entity_filter"] = entity_filter
-
-class Task:
-    def __init__(self, usage=None, **kwargs):
-        self.usage = usage
-        self.actor = usage.actor if usage else None
-        self.usages = []
-    def start_action(self, name, duration=None):
-        return self.actor.start_action(name, duration)
-    def irrelevant(self, *args):
-        return None
-
-server = types.ModuleType("server")
-server.Task = Task
-server.OPERATION_BLOCKED = "blocked"
-sys.modules["server"] = server
-
-world_pkg = types.ModuleType("world")
-sys.modules["world"] = world_pkg
-
-stoppable_task_mod = types.ModuleType("world.StoppableTask")
-class StoppableTask(Task):
-    def __init__(self, usage, **kwargs):
-        super().__init__(usage=usage, **kwargs)
-        self.usages = self.usages + [{"name": "stop"}]
-stoppable_task_mod.StoppableTask = StoppableTask
-sys.modules["world.StoppableTask"] = stoppable_task_mod
-
-utils_mod = types.ModuleType("world.utils")
-class Usage:
-    @staticmethod
-    def set_cooldown_on_attached(tool, actor):
-        pass
-    @staticmethod
-    def delay_task_if_needed(task):
-        return task
-utils_mod.Usage = Usage
-sys.modules["world.utils"] = utils_mod
-
-# --- import Bow module ---
-root = Path(__file__).resolve().parents[3]
-bow_path = root / "apps/cyphesis/data/rulesets/deeds/scripts/world/objects/tools/Bow.py"
-spec = importlib.util.spec_from_file_location("Bow", bow_path)
-Bow = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(Bow)
-
-# --- stubs for actor, tool, usage ---
-
-class Location:
-    def __init__(self):
-        self.pos = Vector3D()
-        self.bbox = types.SimpleNamespace(high_corner=types.SimpleNamespace(y=1.0))
-        self.orientation = None
-    def copy(self):
-        new = Location()
-        new.pos = Vector3D(self.pos)
-        return new
-
-class Actor:
-    def __init__(self):
-        self.id = "actor"
-        self.location = Location()
-        self.actions = []
-        self.sent_world = []
-        self.update_task_called = 0
-    def find_in_contains(self, _):
-        return [types.SimpleNamespace(id="arrow")]
-    def start_action(self, name, duration):
-        self.actions.append((name, duration))
-        return Operation("start_action", Entity(action=name, duration=duration))
-    def send_world(self, op):
-        self.sent_world.append(op)
-    def update_task(self):
-        self.update_task_called += 1
-
-class Tool:
-    def __init__(self):
-        self.id = "bow"
-        self.sent_world = []
-        self.props = types.SimpleNamespace(cooldown=None)
-    def send_world(self, op):
-        self.sent_world.append(op)
-    def get_prop_float(self, name, default=None):
-        return None
-
-class UsageInstance:
-    def __init__(self, actor, tool):
-        self.actor = actor
-        self.tool = tool
-        self.op = Operation("draw")
-    def get_arg(self, name, index):
-        return None
-    def is_valid(self):
-        return True, None
 
 
-def test_bow_animations():
+def test_bow_animations(bow_module, operation, entity, vector3d):
+    Operation = operation
+    Entity = entity
+    Vector3D = vector3d
+
+    class Location:
+        def __init__(self):
+            self.pos = Vector3D()
+            self.bbox = types.SimpleNamespace(high_corner=types.SimpleNamespace(y=1.0))
+            self.orientation = None
+
+        def copy(self):
+            new = Location()
+            new.pos = Vector3D(self.pos)
+            return new
+
+    class Actor:
+        def __init__(self):
+            self.id = "actor"
+            self.location = Location()
+            self.actions = []
+            self.sent_world = []
+            self.update_task_called = 0
+
+        def find_in_contains(self, _):
+            return [types.SimpleNamespace(id="arrow")]
+
+        def start_action(self, name, duration):
+            self.actions.append((name, duration))
+            return Operation("start_action", Entity(action=name, duration=duration))
+
+        def send_world(self, op):
+            self.sent_world.append(op)
+
+        def update_task(self):
+            self.update_task_called += 1
+
+    class Tool:
+        def __init__(self):
+            self.id = "bow"
+            self.sent_world = []
+            self.props = types.SimpleNamespace(cooldown=None)
+
+        def send_world(self, op):
+            self.sent_world.append(op)
+
+        def get_prop_float(self, name, default=None):
+            return None
+
+    class UsageInstance:
+        def __init__(self, actor, tool):
+            self.actor = actor
+            self.tool = tool
+            self.op = Operation("draw")
+
+        def get_arg(self, name, index):
+            return None
+
+        def is_valid(self):
+            return True, None
+
+    Bow = bow_module
     actor = Actor()
     tool = Tool()
     usage = UsageInstance(actor, tool)
@@ -166,13 +71,25 @@ def test_bow_animations():
 
     Bow.shoot_in_direction(direction, usage, res)
 
-    assert any(op.name == "start_action" and op.entity["action"] == "bow/releasing" for op in res)
-    assert any(op.name == "sight" and op.entity.name == "activity" and op.entity.entity["action"] == "shoot" for op in res)
+    assert any(
+        op.name == "start_action" and op.entity["action"] == "bow/releasing" for op in res
+    )
+    assert any(
+        op.name == "sight"
+        and op.entity.name == "activity"
+        and op.entity.entity["action"] == "shoot"
+        for op in res
+    )
 
     task = Bow.DrawBow(usage, tick_interval=0, name="Draw")
     task.setup("t1")
     assert ("bow/drawing", None) in actor.actions
-    assert any(op.name == "sight" and op.entity.name == "activity" and op.entity.entity["action"] == "draw" for op in tool.sent_world)
+    assert any(
+        op.name == "sight"
+        and op.entity.name == "activity"
+        and op.entity.entity["action"] == "draw"
+        for op in tool.sent_world
+    )
 
     task.tick()
     assert task.usages[0]["name"] == "release"


### PR DESCRIPTION
## Summary
- factor reusable Operation, Entity, and Vector3D stubs into `_stubs.py`
- provide pytest fixtures to patch Bow dependencies with mocks
- simplify bow animation test to rely on fixtures and only mock needed interfaces

## Testing
- `pytest apps/tests/e2e/test_bow_animation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9095c7fc0832d81aa10ce2188cdb4