### PR TITLE
Add timeout and error handling for database check

### DIFF
--- a/apps/tests/e2e/minimal_session.py
+++ b/apps/tests/e2e/minimal_session.py
@@ -100,13 +100,21 @@ def main() -> int:
         raise RuntimeError("cyphesis did not start in time")
 
     # Ensure the database has been cleaned before running tests.
+    # Use a short connection timeout to fail fast when the database is unreachable.
+    conn = None
     try:
         import psycopg
-        conn = psycopg.connect("dbname=cyphesis")
+        try:
+            conn = psycopg.connect("dbname=cyphesis", connect_timeout=5)
+        except psycopg.OperationalError as exc:
+            print(f"Database unavailable: {exc}")
     except Exception:
         try:
             import psycopg2 as psycopg
-            conn = psycopg.connect(dbname="cyphesis")
+            try:
+                conn = psycopg.connect(dbname="cyphesis", connect_timeout=5)
+            except psycopg.OperationalError as exc:
+                print(f"Database unavailable: {exc}")
         except Exception:
             conn = None
     if conn is not None:


### PR DESCRIPTION
## Summary
- Use a 5 second `connect_timeout` for psycopg connections in minimal session
- Handle `OperationalError` explicitly to clarify when the database is unavailable

## Testing
- `python apps/tests/e2e/minimal_session.py`
- `pytest apps/tests/e2e/test_bow_animation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90960ea1c832d8bf9ce4e7a90f062