### PR TITLE
Handle connection failure in minimal session

### DIFF
--- a/apps/tests/e2e/minimal_session.py
+++ b/apps/tests/e2e/minimal_session.py
@@ -149,12 +149,17 @@ def main() -> int:
         stdout, _ = client.communicate()
         raise
 
-    if "Connected" not in output and client.returncode != 0:
-        raise RuntimeError(f"ember failed to connect to cyphesis on port {port}")
+    if "Connected" not in stdout and client.returncode != 0:
+        print(f"ember failed to connect to cyphesis on port {port}")
+        return 1
 
     print("E2E session completed")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(exc)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Check ember connection against captured stdout
- Return nonzero exit code when ember fails to connect and handle runtime errors gracefully

## Testing
- `python apps/tests/e2e/minimal_session.py`
- `python -m py_compile apps/tests/e2e/minimal_session.py`


------
https://chatgpt.com/codex/tasks/task_e_68b90c515be0832dbba384fe78120b06