### PR TITLE
Only search for cppunit when building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,14 @@ include(CMakeDependentOption)
 #If no VERSION is set externally, and we can't figure out the Git version, we'll use this version as fallback.
 set(VERSION_FALLBACK "0.9.0-dev")
 
-find_package(cppunit 1.15.1 EXACT)
+# Only look for cppunit when tests are requested.
+if (BUILD_TESTING)
+    find_package(cppunit 1.15.1 EXACT QUIET)
+    if (NOT cppunit_FOUND)
+        message(WARNING "cppunit 1.15.1 not found. Tests will be skipped.")
+    endif ()
+endif ()
+
 find_package(spdlog REQUIRED)
 find_package(Microsoft.GSL REQUIRED)
 


### PR DESCRIPTION
## Summary
- Lookup cppunit only when `BUILD_TESTING` is enabled
- Warn users when tests are requested but cppunit is missing

## Testing
- `cmake -S . -B build_tests -DBUILD_TESTING=ON` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread) (Required is exact version "1.87.0"))*
- `cmake -S . -B build -DBUILD_TESTING=OFF` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread) (Required is exact version "1.87.0"))*

------
https://chatgpt.com/codex/tasks/task_e_68b90c50d1ec832daf114cebd47bc7ff