### PR TITLE
Handle outbound timer errors in MetaServerHandlerUDP

### DIFF
--- a/apps/metaserver/src/server/MetaServerHandlerUDP.cpp
+++ b/apps/metaserver/src/server/MetaServerHandlerUDP.cpp
@@ -31,6 +31,7 @@
  */
 #include <boost/bind.hpp>
 #include <boost/asio/placeholders.hpp>
+#include <boost/asio/error.hpp>
 #include <spdlog/spdlog.h>
 
 MetaServerHandlerUDP::MetaServerHandlerUDP(MetaServer& ms,
@@ -149,11 +150,16 @@ MetaServerHandlerUDP::handle_send(const MetaServerPacket&, const boost::system::
  * @param error
  */
 void
-MetaServerHandlerUDP::process_outbound(const boost::system::error_code&) {
-	//TODO: should we check for errors?
-	boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
-	boost::posix_time::time_duration duration(now.time_of_day());
-	auto tick = duration.total_milliseconds();
+MetaServerHandlerUDP::process_outbound(const boost::system::error_code& error) {
+        if (error) {
+                spdlog::error("Outbound processing failed: {}", error.message());
+                if (error == boost::asio::error::operation_aborted) {
+                        return;
+                }
+        }
+        boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time();
+        boost::posix_time::time_duration duration(now.time_of_day());
+        auto tick = duration.total_milliseconds();
 
 	/*
 	 *  Process the outbound response packets

--- a/apps/metaserver/src/server/MetaServerHandlerUDP.hpp
+++ b/apps/metaserver/src/server/MetaServerHandlerUDP.hpp
@@ -50,9 +50,11 @@ public:
 
 	void handle_receive(const boost::system::error_code& error, std::size_t);
 
-	static void handle_send(const MetaServerPacket& p, const boost::system::error_code& error, std::size_t);
+        static void handle_send(const MetaServerPacket& p, const boost::system::error_code& error, std::size_t);
 
-	void process_outbound(const boost::system::error_code& error);
+        void process_outbound(const boost::system::error_code& error);
+
+        unsigned long getOutboundTick() const { return m_outboundTick; }
 
 
 private:

--- a/apps/metaserver/tests/MetaServerHandlerUDP_unittest.cpp
+++ b/apps/metaserver/tests/MetaServerHandlerUDP_unittest.cpp
@@ -35,6 +35,8 @@
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/extensions/TestFactoryRegistry.h>
 
+#include <boost/asio/error.hpp>
+
 /*
  * Forward Declarations
  */
@@ -46,6 +48,8 @@ class MetaServerHandlerUDP_unittest : public CppUnit::TestCase {
 CPPUNIT_TEST_SUITE(MetaServerHandlerUDP_unittest);
                 CPPUNIT_TEST(testConstructor);
                 CPPUNIT_TEST(testResponseLifetime);
+                CPPUNIT_TEST(testProcessOutboundAbort);
+                CPPUNIT_TEST(testProcessOutboundRetry);
         CPPUNIT_TEST_SUITE_END();
 public:
 	MetaServerHandlerUDP_unittest() {
@@ -92,6 +96,20 @@ public:
 
                 MetaServerPacket rsp(reply, len);
                 CPPUNIT_ASSERT_EQUAL(NMT_HANDSHAKE, rsp.getPacketType());
+        }
+
+        void testProcessOutboundAbort() {
+                CPPUNIT_ASSERT_EQUAL(0UL, ms_udp->getOutboundTick());
+                boost::system::error_code ec = boost::asio::error::operation_aborted;
+                ms_udp->process_outbound(ec);
+                CPPUNIT_ASSERT_EQUAL(0UL, ms_udp->getOutboundTick());
+        }
+
+        void testProcessOutboundRetry() {
+                CPPUNIT_ASSERT_EQUAL(0UL, ms_udp->getOutboundTick());
+                boost::system::error_code ec = boost::asio::error::fault;
+                ms_udp->process_outbound(ec);
+                CPPUNIT_ASSERT(ms_udp->getOutboundTick() > 0);
         }
 };
 


### PR DESCRIPTION
## Summary
- Add error handling to `MetaServerHandlerUDP::process_outbound` to log and gracefully abort on timer failures
- Expose `getOutboundTick` for diagnostics
- Test timer error scenarios for abort and retry behavior

## Testing
- `cmake -S . -B build` *(fails: Could NOT find Boost (missing: Boost_INCLUDE_DIR thread) (Required is exact version "1.87.0"))*

------
https://chatgpt.com/codex/tasks/task_e_68b9c5c0cc74832db0a0be0672f84b35