### PR TITLE
Handle ShutdownException separately in metaserver

### DIFF
--- a/apps/metaserver/src/server/ShutdownException.hpp
+++ b/apps/metaserver/src/server/ShutdownException.hpp
@@ -1,0 +1,15 @@
+#ifndef METASERVER_SHUTDOWNEXCEPTION_HPP
+#define METASERVER_SHUTDOWNEXCEPTION_HPP
+
+#include <stdexcept>
+#include <string>
+
+/**
+ * Exception used to signal a graceful shutdown of the metaserver.
+ */
+class ShutdownException : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
+#endif // METASERVER_SHUTDOWNEXCEPTION_HPP


### PR DESCRIPTION
## Summary
- Introduce a dedicated `ShutdownException` class for graceful server shutdown signaling
- Refine metaserver `main.cpp` to catch `ShutdownException` explicitly and rethrow other exceptions

## Testing
- ⚠️ `cmake --build --preset conan-release --target metaserver -j 2` *(failed: Could not read presets)*
- ⚠️ `g++ -std=c++17 -Iapps/metaserver/src/server -Iapps/metaserver/src -Iapps/metaserver/src/api -c -fsyntax-only apps/metaserver/src/server/main.cpp` *(failed: boost/date_time/posix_time/posix_time.hpp: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68b9c9905694832da33b8ccdb8f6afa5