### PR TITLE
Remove unused mind assignment from NPCMind

### DIFF
--- a/apps/cyphesis/data/rulesets/basic/scripts/mind/NPCMind.py
+++ b/apps/cyphesis/data/rulesets/basic/scripts/mind/NPCMind.py
@@ -53,9 +53,7 @@ class NPCMind(ai.Mind):
 
     # Initialization
     def __init__(self, cppthing):
-        # FIXME: this shouldn't be needed
-        self.mind = cppthing
-
+        # cppthing is provided by the engine but not used here
         # print('init')
 
         self.knowledge = Knowledge()


### PR DESCRIPTION
## Summary
- Drop unused `self.mind` assignment from NPCMind initializer
- Document that `cppthing` parameter is provided but unused

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'atlas')

------
https://chatgpt.com/codex/tasks/task_e_68b9c996ea6c832d8e4641769d365cb3