### PR TITLE
Fail E2E minimal session on connection issues

### DIFF
--- a/apps/tests/e2e/minimal_session.py
+++ b/apps/tests/e2e/minimal_session.py
@@ -149,9 +149,9 @@ def main() -> int:
         stdout, _ = client.communicate()
         raise
 
-    if "Connected" not in stdout and client.returncode != 0:
+    if "Connected" not in stdout or client.returncode != 0:
         print(f"ember failed to connect to cyphesis on port {port}")
-        return 1
+        return client.returncode or 1
 
     print("E2E session completed")
     return 0


### PR DESCRIPTION
## Summary
- Tighten minimal session check to fail if the client doesn't report "Connected" or exits with an error
- Propagate client return code when connection fails

## Testing
- `pytest apps/tests/e2e/test_bow_animation.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba2a59adbc832d9d10e6c6a12c9467