### PR TITLE
chore: log widget plugin build option

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -137,7 +137,7 @@ class Worldforge(ConanFile):
             tc.variables["BUILD_METASERVER_SERVER"] = "TRUE"
 
         if self.options.widgets_as_plugins:
-            print("Widgets will be built as plugins, which is mainly of use during development.")
+            self.output.info("Widgets will be built as plugins, which is mainly of use during development.")
             tc.variables["WF_USE_WIDGET_PLUGINS"] = "TRUE"
 
         tc.generate()


### PR DESCRIPTION
## Summary
- log widget plugin build message through Conan's output helper

## Testing
- `conan install conanfile_test.py` *(fails: Existing CMakePresets.json not generated by Conan cannot be overwritten)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2a5b135c832d939ed440a62b07e1