### PR TITLE
docs: update media download target name

### DIFF
--- a/apps/ember/README.md
+++ b/apps/ember/README.md
@@ -22,7 +22,7 @@ slope angle in degrees (default `70`).
 
 ### Working with media
 
-An alternative to the ```media-download``` target is to instead use the raw media repo source, as found at
+An alternative to the ```media-download-rsync``` target is to instead use the raw media repo source, as found at
 https://svn.worldforge.org:886/svn/media/trunk/. If you intend to edit or add new media you probably want this instead.
 
 The target ```mediarepo-checkout``` will use Subversion to checkout the repository to the ```mediarepo``` directory.


### PR DESCRIPTION
## Summary
- fix outdated media-download target in Ember README
- verify mediarepo-checkout and media-download-rsync targets exist in CMake scripts

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_68ba2a5cffd4832d88ada3e4b3f18cee