### PR TITLE
Add unit test for client session cache expiration

### DIFF
--- a/apps/metaserver/tests/CMakeLists.txt
+++ b/apps/metaserver/tests/CMakeLists.txt
@@ -42,6 +42,18 @@ if (BUILD_METASERVER_SERVER)
     add_dependencies(check DataObject_unittest)
 
 
+    add_executable(ClientSessionCache_unittest
+            ClientSessionCache_unittest.cpp
+            ../src/server/DataObject.cpp)
+    target_link_libraries(ClientSessionCache_unittest PUBLIC
+            cppunit::cppunit
+            Boost::program_options
+            spdlog::spdlog
+    )
+    add_test(NAME ClientSessionCache_unittest COMMAND ClientSessionCache_unittest)
+    add_dependencies(check ClientSessionCache_unittest)
+
+
     add_executable(MetaServerHandlerUDP_unittest
             MetaServerHandlerUDP_unittest.cpp
             ../src/server/MetaServerHandlerUDP.cpp

--- a/apps/metaserver/tests/ClientSessionCache_unittest.cpp
+++ b/apps/metaserver/tests/ClientSessionCache_unittest.cpp
@@ -1,0 +1,51 @@
+/**
+ * Verify that DataObject::expireClientSessionCache removes expired entries
+ */
+#define private public
+#include "../src/server/DataObject.hpp"
+#undef private
+
+#include <cppunit/TestCase.h>
+#include <cppunit/TestRunner.h>
+#include <cppunit/TextTestRunner.h>
+#include <cppunit/TestListener.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/extensions/TestFactoryRegistry.h>
+
+#include <algorithm>
+
+class ClientSessionCache_unittest : public CppUnit::TestFixture {
+CPPUNIT_TEST_SUITE(ClientSessionCache_unittest);
+    CPPUNIT_TEST(test_ExpireClientSessionCache);
+CPPUNIT_TEST_SUITE_END();
+
+private:
+    DataObject* msdo;
+public:
+    void setUp() override {
+        msdo = new DataObject();
+    }
+    void tearDown() override {
+        delete msdo;
+    }
+
+    void test_ExpireClientSessionCache() {
+        msdo->addServerSession("server1");
+        msdo->createServerSessionListresp("client1");
+        boost::posix_time::ptime old = DataObject::getNow() - boost::posix_time::seconds(10);
+        msdo->m_listreqExpiry["client1"] = boost::posix_time::to_iso_string(old);
+        std::vector<std::string> expired = msdo->expireClientSessionCache(5);
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), expired.size());
+        CPPUNIT_ASSERT(std::find(expired.begin(), expired.end(), std::string("client1")) != expired.end());
+        CPPUNIT_ASSERT(msdo->getServerSessionCacheList().empty());
+    }
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(ClientSessionCache_unittest);
+
+int main(int argc, char** argv) {
+    CppUnit::TextTestRunner runner;
+    runner.addTest(CppUnit::TestFactoryRegistry::getRegistry().makeTest());
+    bool wasSuccessful = runner.run();
+    return wasSuccessful ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add CppUnit test verifying DataObject::expireClientSessionCache purges expired entries
- hook new test into metaserver test CMake build

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog" with any of the following names: spdlogConfig.cmake, spdlog-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68ba332d4064832da1f2a963b84d91c5