### PR TITLE
Simplify empty map returns in DataObject

### DIFF
--- a/apps/metaserver/src/server/DataObject.cpp
+++ b/apps/metaserver/src/server/DataObject.cpp
@@ -168,14 +168,11 @@ DataObject::addClientFilter(const std::string& sessionid, const std::string& nam
 
 std::map<std::string, std::string>
 DataObject::getClientFilter(const std::string& sessionid) {
-	std::map<std::string, std::string> empty;
-	empty.clear();
-
-	if (keyExists<std::string>(m_clientFilterData, sessionid) &&
-		keyExists<std::string>(m_clientData, sessionid)) {
-		return m_clientFilterData[sessionid];
-	}
-	return empty;
+        if (keyExists<std::string>(m_clientFilterData, sessionid) &&
+                keyExists<std::string>(m_clientData, sessionid)) {
+                return m_clientFilterData[sessionid];
+        }
+        return {};
 }
 
 std::string
@@ -243,12 +240,9 @@ DataObject::serverSessionExists(const std::string& sessionid) {
 
 std::map<std::string, std::string>
 DataObject::getServerSession(const std::string& sessionid) {
-	if (keyExists<std::string>(m_serverData, sessionid))
-		return m_serverData[sessionid];
-
-	std::map<std::string, std::string> empty;
-	empty.clear();
-	return empty;
+        if (keyExists<std::string>(m_serverData, sessionid))
+                return m_serverData[sessionid];
+        return {};
 }
 
 bool DataObject::addClientSession(const std::string& sessionid) {
@@ -415,13 +409,9 @@ DataObject::searchServerSessionByAttribute(const std::string& attr_name, const s
 
 std::map<std::string, std::string>
 DataObject::getClientSession(const std::string& sessionid) {
-	if (keyExists<std::string>(m_clientData, sessionid))
-		return m_clientData[sessionid];
-
-	// @TODO: there has to be a way to do this without polluting the stack
-	std::map<std::string, std::string> empty;
-	empty.clear();
-	return empty;
+        if (keyExists<std::string>(m_clientData, sessionid))
+                return m_clientData[sessionid];
+        return {};
 }
 
 std::vector<std::string>


### PR DESCRIPTION
## Summary
- Return empty map directly in DataObject helper methods instead of creating and clearing temporaries.

## Testing
- `g++ -std=c++17 apps/metaserver/tests/DataObject_unittest.cpp apps/metaserver/src/server/DataObject.cpp -Iapps/metaserver/src/server -Iapps/metaserver/src/api -Iapps/metaserver/tests -lcppunit -lfmt -lspdlog -lboost_date_time -lboost_program_options -lboost_system -pthread -o DataObject_unittest`
- `./DataObject_unittest`


------
https://chatgpt.com/codex/tasks/task_e_68ba332e6d00832db7d613979e845c9b