### PR TITLE
Fix logging for client session cache expiry

### DIFF
--- a/apps/metaserver/src/server/MetaServer.cpp
+++ b/apps/metaserver/src/server/MetaServer.cpp
@@ -162,10 +162,10 @@ MetaServer::expiry_timer(const boost::system::error_code&) {
 	/*
 	 * We want to purge any cache items that are missing
 	 */
-	std::vector<std::string> expiredCSC = msdo.expireClientSessionCache(m_serverClientCacheExpirySeconds);
-	if (!expiredCS.empty()) {
-		spdlog::trace("Expiry ClientSession Cache: {}", expiredCS.size());
-	}
+        std::vector<std::string> expiredCSC = msdo.expireClientSessionCache(m_serverClientCacheExpirySeconds);
+        if (!expiredCSC.empty()) {
+                spdlog::trace("Expiry ClientSession Cache: {}", expiredCSC.size());
+        }
 
 	/**
      * Display Server Sessions and Attributes


### PR DESCRIPTION
## Summary
- fix MetaServer logging to use expired client session cache results

## Testing
- `conan install . -o with_client=False -o with_server=False -o without_metaserver_server=False --output-folder=build --build=missing` *(fails: Exiting with code: 3)*
- `/tmp/test_expired_csc`


------
https://chatgpt.com/codex/tasks/task_e_68ba332987c0832dbc9a80ae465222cb