### PR TITLE
docs: document Python prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,10 @@ how they work.
 The simplest way to install all required dependencies is by using
 [Conan](https://www.conan.io). This setup requires CMake 3.23+.
 
-Make sure you have installed a c++ compiler (g++ or clang), Conan,
+Make sure you have installed a c++ compiler (g++ or clang), Python 3, Conan,
 CMake, Subversion and ImageMagick (if you're building the server).
+Python is used for code generation (for example, generating Atlas objects)
+and for server scripting.
 
 ### Dependency setup
 


### PR DESCRIPTION
## Summary
- note Python 3 as a required dependency
- clarify Python powers Atlas object code generation and server scripts

## Testing
- `npx markdownlint-cli README.md` *(fails: MD013 line-length, MD034 bare URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ba36a1f0e8832db394562fd79166ee