### PR TITLE
Enable warnings in atlas tests

### DIFF
--- a/libs/atlas/CMakeLists.txt
+++ b/libs/atlas/CMakeLists.txt
@@ -93,7 +93,7 @@ macro(wf_add_test TEST_FILE)
         add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_FILE} ${ARGN})
     endif (BUILD_TESTING)
 
-    target_compile_options(${TEST_NAME} PUBLIC "-w")
+    target_compile_options(${TEST_NAME} PRIVATE ${WF_WARNING_FLAGS})
     target_include_directories(${TEST_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/src")
     add_test(NAME ${TEST_NAME} COMMAND $<TARGET_FILE:${TEST_NAME}>)
     #We need to tell adjust the path so tests on windows can find the .dll files.


### PR DESCRIPTION
## Summary
- remove blanket warning suppression from atlas tests
- build tests with repository warning flags

## Testing
- `cmake -S libs/atlas -B build/atlas -DBUILD_TESTING=ON -DCMAKE_PROJECT_INCLUDE_BEFORE=/tmp/include.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWF_WARNING_FLAGS="-Wall;-Wextra"`
- `cmake --build build/atlas --target ElementTest -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68ba36a011d0832d882500f867c1184b