### PR TITLE
Rename Environment::setTime to setTimeInSeconds

### DIFF
--- a/apps/ember/src/components/ogre/environment/Environment.cpp
+++ b/apps/ember/src/components/ogre/environment/Environment.cpp
@@ -131,8 +131,8 @@ void Environment::setTime(int hour, int minute, int second) {
 	mProvider->setTime(hour, minute, second);
 }
 
-void Environment::setTime(int seconds) {
-	mProvider->setTime(seconds);
+void Environment::setTimeInSeconds(int seconds) {
+        mProvider->setTime(seconds);
 }
 
 void Environment::setTimeMultiplier(float multiplier) {

--- a/apps/ember/src/components/ogre/environment/Environment.h
+++ b/apps/ember/src/components/ogre/environment/Environment.h
@@ -101,12 +101,11 @@ public:
 	 */
 	void setTime(int hour, int minute, int second = 0);
 
-	/**
-	 * @brief Sets the current time.
-	 * @param seconds Seconds since midnight.
-	 * TODO: rename to setTimeInSeconds
-	 */
-	void setTime(int seconds);
+        /**
+         * @brief Sets the current time using seconds since midnight.
+         * @param seconds Seconds since midnight.
+         */
+        void setTimeInSeconds(int seconds);
 
 	/**
 	 * @brief Sets the time multiplier, i.e. how much the time of the environment will progress per real time second.

--- a/apps/ember/src/components/ogre/scripting/bindings/lua/LuaEnvironment.cpp
+++ b/apps/ember/src/components/ogre/scripting/bindings/lua/LuaEnvironment.cpp
@@ -33,10 +33,10 @@ void registerLua<Environment>(sol::table& space) {
 	iFog["getDensity"] = &IFog::getDensity;
 
 	auto environment = space.new_usertype<Ember::OgreView::Environment::Environment>("Environment", sol::no_constructor);
-	environment["getSun"] = &Ember::OgreView::Environment::Environment::getSun;
-	environment["getFog"] = &Ember::OgreView::Environment::Environment::getFog;
-	environment["setTime"] = [](Ember::OgreView::Environment::Environment* self, int seconds) { self->setTime(seconds); };
-	environment["setTimeMultiplier"] = &Ember::OgreView::Environment::Environment::setTimeMultiplier;
+        environment["getSun"] = &Ember::OgreView::Environment::Environment::getSun;
+        environment["getFog"] = &Ember::OgreView::Environment::Environment::getFog;
+        environment["setTimeInSeconds"] = [](Ember::OgreView::Environment::Environment* self, int seconds) { self->setTimeInSeconds(seconds); };
+        environment["setTimeMultiplier"] = &Ember::OgreView::Environment::Environment::setTimeMultiplier;
 	environment["getTimeMultiplier"] = &Ember::OgreView::Environment::Environment::getTimeMultiplier;
 	environment["setAmbientLight"] = &Ember::OgreView::Environment::Environment::setAmbientLight;
 

--- a/apps/ember/src/components/ogre/widgets/Environment.lua
+++ b/apps/ember/src/components/ogre/widgets/Environment.lua
@@ -15,7 +15,7 @@ function Environment:buildWidget(environmentObject)
 	self.timeSlider:subscribeEvent("ValueChanged", function()
 		local timeValue = self.timeSlider:getCurrentValue()
 
-		self.environment:setTime(math.floor(86400 * timeValue))
+                self.environment:setTimeInSeconds(math.floor(86400 * timeValue))
 		return true
 	end)
 


### PR DESCRIPTION
## Summary
- rename `Environment::setTime(int seconds)` to `setTimeInSeconds(int seconds)`
- adjust Lua bindings and widget to use `setTimeInSeconds`

## Testing
- `cmake -B build -S .` *(fails: Could not find package configuration file provided by "spdlog")*
- `cmake --build build --target ember` *(fails: No rule to make target 'Makefile')*


------
https://chatgpt.com/codex/tasks/task_e_68bb1ffc551c832dac42ee34ea46f95b