### PR TITLE
Remove obsolete data/dural resource path

### DIFF
--- a/apps/ember/CMakeLists.txt
+++ b/apps/ember/CMakeLists.txt
@@ -123,15 +123,6 @@ add_subdirectory(external)
 add_subdirectory(src)
 add_subdirectory(tests)
 
-file(GLOB MODELDEFINITIONS_FILES data/dural/*.modeldef)
-foreach (FILE ${MODELDEFINITIONS_FILES})
-    add_custom_command(
-            TARGET check
-            POST_BUILD
-            COMMAND "${XMLLINT}" --schema "${PROJECT_SOURCE_DIR}/data/modeldefinition.xsd" --nonet --noout "${FILE}"
-    )
-endforeach ()
-
 configure_file(tools/Version.tmpl.h generated/Version.h @ONLY)
 configure_file(tools/bintray.tmpl.json bintray.json @ONLY)
 message(STATUS "Installing snapcraft.yaml file into build directory. Copy this one to the installation directory if you want to build snaps.")

--- a/apps/ember/src/components/ogre/OgreResourceLoader.cpp
+++ b/apps/ember/src/components/ogre/OgreResourceLoader.cpp
@@ -325,10 +325,8 @@ void OgreResourceLoader::loadGeneral() {
 	addSharedMedia("scripting", "EmberFileSystem", "Scripting");
 	addUserMedia("scripting", "EmberFileSystem", "Scripting");
 
-	//Model definitions, terrain definitions, sound definitions and entity mappings
-	//TODO: remove
-	addSharedMedia("data/dural", "EmberFileSystem", "Data");
-	addUserMedia("data", "EmberFileSystem", "Data");
+        //Model definitions, terrain definitions, sound definitions and entity mappings
+        addUserMedia("data", "EmberFileSystem", "Data");
 
 	//The Caelum component
 	addSharedMedia("data/caelum", "EmberFileSystem", "Caelum");


### PR DESCRIPTION
## Summary
- drop unused `data/dural` media path from Ogre resource loader
- clean CMake script of `data/dural` model definition glob

## Testing
- `conan install . --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True` *(fails: Requirement 'ogre-next/2.3.0@worldforge' not in lockfile)*
- `cmake -S . -B build` *(fails: Could not find package 'spdlog')*


------
https://chatgpt.com/codex/tasks/task_e_68bb2000cef0832daa57b28fc57a1d2b