### PR TITLE
refactor: replace LodManager template helpers with lambdas

### DIFF
--- a/apps/ember/src/components/ogre/lod/LodManager.h
+++ b/apps/ember/src/components/ogre/lod/LodManager.h
@@ -69,14 +69,6 @@ public:
 
         /// Stream Nanite style clusters into the mesh on demand
         static void loadLod(Ogre::MeshPtr mesh, const NaniteLodDefinition& definition);
-
-private:
-
-	template<typename T>
-	static void loadUserLodImpl(T it, T itEnd, Ogre::Mesh* mesh);
-
-	template<typename T>
-	static void loadAutomaticLodImpl(T it, T itEnd, Ogre::LodConfig& lodConfig);
 };
 
 }


### PR DESCRIPTION
## Summary
- Replace template helper functions for LOD setup with inline lambdas
- Simplify LodManager interface by removing unused template declarations

## Testing
- `clang-format -i apps/ember/src/components/ogre/lod/LodManager.h apps/ember/src/components/ogre/lod/LodManager.cpp` *(fails: invalid `.clang-format` configuration)*
- `cmake --build build/lod` *(fails: fatal error: sigc++/connection.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1ff9fcdc832da4c123037181ecb6