### PR TITLE
Add MetaServer networking API

### DIFF
--- a/apps/metaserver/README.md
+++ b/apps/metaserver/README.md
@@ -1,4 +1,4 @@
-# Metaserver
+#Metaserver
 
 ## Introduction
 Welcome to the WorldForge Next Generation MetaServer!
@@ -99,6 +99,25 @@ server_stats=true
 
 ## MetaServer Protocol
 Refer to `PROTOCOL` document.
+
+## MetaServer API
+The API library contains utilities for communicating with the
+MetaServer over UDP.  Create an instance with a target host and port
+and then use `sendPacket`/`receivePacket` to exchange
+`MetaServerPacket` messages.
+
+```cpp
+#include "MetaServerAPI.hpp"
+
+MetaServerAPI api("example.org", 8453);
+MetaServerPacket packet;
+packet.setPacketType(NMT_HANDSHAKE);
+api.sendPacket(packet);
+
+MetaServerPacket reply = api.receivePacket();
+```
+
+The destination can be changed at runtime with `setEndpoint()`.
 
 ## Contributors
 All contributors will be listed in the `AUTHORS` file.

--- a/apps/metaserver/src/api/CMakeLists.txt
+++ b/apps/metaserver/src/api/CMakeLists.txt
@@ -1,6 +1,13 @@
+wf_find_boost(system headers)
+
 add_library(metaserver-api
         MetaServerPacket.cpp
+        MetaServerAPI.cpp
+)
+
+target_link_libraries(metaserver-api PUBLIC
+        Boost::headers
+        Boost::system
 )
 
 target_include_directories(metaserver-api PUBLIC .)
-

--- a/apps/metaserver/src/api/MetaServerAPI.cpp
+++ b/apps/metaserver/src/api/MetaServerAPI.cpp
@@ -1,0 +1,39 @@
+#include "MetaServerAPI.hpp"
+
+MetaServerAPI::MetaServerAPI(const std::string &host, unsigned short port)
+    : m_ioContext(), m_endpoint(), m_socket(m_ioContext) {
+  setEndpoint(host, port);
+}
+
+void MetaServerAPI::setEndpoint(const std::string &host, unsigned short port) {
+  boost::system::error_code ec;
+  if (m_socket.is_open()) {
+    m_socket.close(ec);
+  }
+  m_endpoint = boost::asio::ip::udp::endpoint(
+      boost::asio::ip::make_address(host, ec), port);
+  m_socket.open(boost::asio::ip::udp::v4(), ec);
+  if (ec) {
+    throw boost::system::system_error(ec);
+  }
+  m_socket.connect(m_endpoint, ec);
+  if (ec) {
+    throw boost::system::system_error(ec);
+  }
+}
+
+void MetaServerAPI::sendPacket(const MetaServerPacket &packet) {
+  m_socket.send(
+      boost::asio::buffer(packet.getBuffer().data(), packet.getSize()));
+}
+
+MetaServerPacket MetaServerAPI::receivePacket() {
+  std::array<char, MAX_PACKET_BYTES> buf;
+  boost::asio::ip::udp::endpoint sender;
+  std::size_t len = m_socket.receive_from(boost::asio::buffer(buf), sender);
+  MetaServerPacket packet(buf, len);
+  packet.setAddress(sender.address().to_string(),
+                    sender.address().to_v4().to_uint());
+  packet.setPort(sender.port());
+  return packet;
+}

--- a/apps/metaserver/src/api/MetaServerAPI.hpp
+++ b/apps/metaserver/src/api/MetaServerAPI.hpp
@@ -23,17 +23,51 @@
 #define METASERVERAPI_HPP_
 
 /*
- * Packet is the core of the API, allowing for any local transport 
+ * Packet is the core of the API, allowing for any local transport
  * mechanisms.
  */
-#include "MetaServerVersion.hpp"
-#include "MetaServerProtocol.hpp"
 #include "MetaServerPacket.hpp"
+#include "MetaServerProtocol.hpp"
+#include "MetaServerVersion.hpp"
 
-/*
- * TODO: Add in a default transport mechanism using boost
- * sendPacket
- * receivePacket
+#include <boost/asio.hpp>
+#include <string>
+
+/**
+ * Simple helper for sending and receiving MetaServer packets over the
+ * network.  The API currently uses UDP via boost::asio.  The target
+ * endpoint can be configured through the constructor or later via the
+ * setEndpoint method.
  */
+class MetaServerAPI {
+public:
+  /**
+   * Construct the API with an optional remote host and port.  The
+   * default points to the standard MetaServer port on localhost.
+   */
+  MetaServerAPI(const std::string &host = "127.0.0.1",
+                unsigned short port = 8453);
+
+  /**
+   * Change the remote endpoint used for subsequent send/receive
+   * operations.
+   */
+  void setEndpoint(const std::string &host, unsigned short port);
+
+  /**
+   * Send a packet to the configured endpoint.
+   */
+  void sendPacket(const MetaServerPacket &packet);
+
+  /**
+   * Blocking receive of a packet from the configured endpoint.
+   */
+  MetaServerPacket receivePacket();
+
+private:
+  boost::asio::io_context m_ioContext;
+  boost::asio::ip::udp::endpoint m_endpoint;
+  boost::asio::ip::udp::socket m_socket;
+};
 
 #endif /* METASERVERAPI_HPP_ */


### PR DESCRIPTION
## Summary
- provide MetaServerAPI for UDP communication using Boost.Asio
- allow configuring remote endpoint and sending/receiving packets
- document MetaServerAPI usage in README

## Testing
- `cmake -S . -B build` *(fails: Could not find spdlog)*
- `conan install . --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True` *(fails: requirement 'ogre-next/2.3.0@worldforge' not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68bb238bb7d4832d85292760acaf18d4