### PR TITLE
Guard ComboboxAdapter against invalid widgets

### DIFF
--- a/apps/ember/src/components/ogre/widgets/adapters/ComboboxAdapter.h
+++ b/apps/ember/src/components/ogre/widgets/adapters/ComboboxAdapter.h
@@ -25,6 +25,7 @@
 
 #include "GenericPropertyAdapter.h"
 #include "../ColouredListItem.h"
+#include "framework/Exception.h"
 #include <CEGUI/widgets/Combobox.h>
 #include <CEGUI/widgets/Editbox.h>
 #include <CEGUI/widgets/PushButton.h>
@@ -60,10 +61,12 @@ template<typename ValueType, typename PropertyNativeType>
 ComboboxAdapter<ValueType, PropertyNativeType>::ComboboxAdapter(const ValueType& value, CEGUI::Window* widget):
 		GenericPropertyAdapter<ValueType, PropertyNativeType>(value, widget, "Text", CEGUI::Combobox::EventListSelectionAccepted),
 		mCombobox(dynamic_cast<CEGUI::Combobox*>(widget)) {
-	// TODO: Do we want to assert that given widget is a combobox or just silently not provide the
-	//       functionality specific to the combobox?
+        if (!mCombobox) {
+                logger->error("ComboboxAdapter constructed with non-combobox widget.");
+                throw Exception("ComboboxAdapter requires a CEGUI::Combobox widget");
+        }
 
-	if (mCombobox) {
+        if (mCombobox) {
 		this->addGuiEventConnection(mCombobox->getEditbox()->subscribeEvent(CEGUI::Window::EventDeactivated,
 																			[this](const CEGUI::EventArgs& e) {
 																				auto initialValue = this->mEditedValue;

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -91,6 +91,15 @@ if (TARGET cppunit::cppunit)
     add_test(NAME TestEmberServices COMMAND TestEmberServices)
     add_dependencies(check TestEmberServices)
 
+    add_executable(ComboboxAdapterTest
+            ComboboxAdapterTest.cpp)
+    target_compile_definitions(ComboboxAdapterTest PUBLIC -DLOG_TASKS)
+    target_link_libraries(ComboboxAdapterTest
+            cppunit::cppunit
+            ember-widgets)
+    add_test(NAME ComboboxAdapterTest COMMAND ComboboxAdapterTest)
+    add_dependencies(check ComboboxAdapterTest)
+
     #    add_executable(TestTerrain TestTerrain.cpp)
     #    target_compile_definitions(TestTerrain PUBLIC -DLOG_TASKS)
     #    target_link_libraries(TestTerrain ${CPPUNIT_LIBRARIES} ${WF_LIBRARIES} emberogre terrain caelum pagedgeometry entitymapping lua services framework)

--- a/apps/ember/tests/ComboboxAdapterTest.cpp
+++ b/apps/ember/tests/ComboboxAdapterTest.cpp
@@ -1,0 +1,40 @@
+#include <cppunit/extensions/TestFactoryRegistry.h>
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/BriefTestProgressListener.h>
+#include <cppunit/TestResult.h>
+
+#include "components/ogre/widgets/adapters/ComboboxAdapter.h"
+
+namespace Ember {
+
+class ComboboxAdapterTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(ComboboxAdapterTestCase);
+        CPPUNIT_TEST(testThrowsOnInvalidWidget);
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void testThrowsOnInvalidWidget() {
+                CEGUI::Window* notACombobox = nullptr;
+                CPPUNIT_ASSERT_THROW(
+                                OgreView::Gui::Adapters::ComboboxAdapter<std::string, std::string> adapter("", notACombobox),
+                                Exception);
+        }
+};
+
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(Ember::ComboboxAdapterTestCase);
+
+int main(int argc, char** argv) {
+        CppUnit::TextUi::TestRunner runner;
+        CppUnit::TestFactoryRegistry& registry = CppUnit::TestFactoryRegistry::getRegistry();
+        runner.addTest(registry.makeTest());
+
+        CppUnit::BriefTestProgressListener listener;
+        runner.eventManager().addListener(&listener);
+
+        bool wasSuccessful = runner.run("", false);
+        return !wasSuccessful;
+}
+


### PR DESCRIPTION
## Summary
- throw an exception when ComboboxAdapter is given a non-combobox widget
- add test ensuring invalid widget usage is reported

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*


------
https://chatgpt.com/codex/tasks/task_e_68bb238d70fc832d87c0ddc0a6a7c1ad