### PR TITLE
Fix SDL linking and re-enable macOS builds

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -23,9 +23,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                #Enable building on macOS when it can be fixed. Currently, we're getting SDL linking errors.
-                #        os: [ ubuntu-22.04, macos-12, macos-11 ]
-                os: [ ubuntu-22.04, ubuntu-24.04, windows-2022 ]
+                os: [ ubuntu-22.04, ubuntu-24.04, macos-14, windows-2022 ]
 
         steps:
             -   uses: actions/checkout@v4.2.2

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -21,9 +21,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                #Enable building on macOS when it can be fixed. Currently, we're getting SDL linking errors.
-                #        os: [ ubuntu-22.04, macos-12, macos-11 ]
-                os: [ ubuntu-22.04, ubuntu-24.04, windows-2022 ]
+                os: [ ubuntu-22.04, ubuntu-24.04, macos-14, windows-2022 ]
 
         steps:
             -   uses: actions/checkout@v4.2.2

--- a/apps/ember/src/components/cegui/CMakeLists.txt
+++ b/apps/ember/src/components/cegui/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(ember-cegui PUBLIC
         ember-external-CEGUIOgreRenderer
         varconf
         cegui::cegui
+        SDL3::SDL3
 )
 
 file(GLOB CEGUI_FILES bindings/lua/*.cpp)

--- a/apps/ember/src/services/CMakeLists.txt
+++ b/apps/ember/src/services/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(ember-services PUBLIC
         ember-external-mojoal
         varconf
         Vorbis::vorbisfile
+        SDL3::SDL3
 )
 
 


### PR DESCRIPTION
## Summary
- link SDL explicitly for CEGUI and services components
- add macOS 14 runners back to build matrices

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_68bb31830464832d9759c3ce29acc3ef