### PR TITLE
Add e2e pytest test and document dependency

### DIFF
--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,1 +1,3 @@
 conan
+pytest
+

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ cmake --build . -j --target media-process-install
 
 ### Tests
 
+The Python-based end-to-end tests require [pytest](https://pytest.org).
+Install it with `pip install pytest`.
+
 The test suite can be built and run using the ```check``` target. For example:
 
 ```bash

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -7,3 +7,7 @@ endif ()
 if (NOT SKIP_CYPHESIS OR BUILD_METASERVER_SERVER)
   add_subdirectory(metaserver)
 endif ()
+
+if (BUILD_TESTING)
+  add_test(NAME e2e COMMAND pytest apps/tests/e2e)
+endif ()


### PR DESCRIPTION
## Summary
- Add `pytest`-based end-to-end test to apps CMake configuration
- Document pytest requirement and include it in CI requirements

## Testing
- `pytest apps/tests/e2e -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb50ca0078832d9e6210bae0be5d81