### PR TITLE
Run Atlas Python tests via pytest

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -70,6 +70,10 @@ jobs:
                     sed -i.backup 's/compiler.cppstd=14/compiler.cppstd=17/g' ~/.conan2/profiles/default
                     conan remote add worldforge https://artifactory.ogenvik.org/artifactory/api/conan/conan-local
 
+            -   name: Verify Python packages
+                shell: bash
+                run: python -m pytest --version
+
             -   name: Have Conan install packages
                 shell: bash
                 run: |

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,1 +1,3 @@
 conan
+pytest
+

--- a/libs/atlas/CMakeLists.txt
+++ b/libs/atlas/CMakeLists.txt
@@ -159,6 +159,18 @@ wf_add_benchmark(tests/benchmark/Codecs_Packed.cpp)
 wf_add_benchmark(tests/benchmark/Message_Element.cpp)
 wf_add_benchmark(tests/benchmark/Objects_setAttr.cpp)
 
+# Python tests for Atlas-Python bindings
+if (Python3_EXECUTABLE)
+    add_test(
+            NAME atlas_python_tests
+            COMMAND ${Python3_EXECUTABLE} -m pytest tests
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/Atlas-Python
+    )
+    set_tests_properties(atlas_python_tests PROPERTIES
+            ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/src/Atlas-Python"
+    )
+endif ()
+
 # Doxygen support, exports a "dox" target.
 
 find_package(Doxygen)


### PR DESCRIPTION
## Summary
- add CMake test that runs pytest against Atlas-Python bindings
- ensure pytest is installed and checked in CI

## Testing
- `PYTHONPATH=libs/atlas/src/Atlas-Python python3 -m pytest libs/atlas/src/Atlas-Python/tests` *(fails: ModuleNotFoundError: No module named 'codec')*

------
https://chatgpt.com/codex/tasks/task_e_68bb50cc1e2c832d909996fa7495e65c