### PR TITLE
Fail build when cppunit is missing

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -53,7 +53,7 @@ jobs:
                 if: runner.os == 'Linux'
                 with:
                     #Needed for the assets processing step in Cyphesis
-                    packages: imagemagick file rsync libfuse2
+                    packages: imagemagick file rsync libfuse2 libcppunit-dev
                     version: 1.0
 
             -   name: Setup environment
@@ -74,11 +74,15 @@ jobs:
                 shell: bash
                 if: runner.os == 'macOS'
                 run: |
-                    brew install autoconf automake
+                    brew install autoconf automake cppunit
 
             -   name: Install Windows tools
                 if: runner.os == 'Windows'
                 uses: "GuillaumeFalourd/setup-rsync@v1.2"
+
+            -   name: Install cppunit (Windows)
+                if: runner.os == 'Windows'
+                run: choco install -y cppunit
 
             -   name: Install LXD (for Snapcraft)
                 if: env.BUILD_SNAP == 'true'
@@ -223,7 +227,7 @@ jobs:
                 if: runner.os == 'Linux'
                 with:
                     #Needed for the assets processing step in Cyphesis
-                    packages: imagemagick file rsync libfuse2
+                    packages: imagemagick file rsync libfuse2 libcppunit-dev
                     version: 1.0
 
             -   name: Setup environment
@@ -244,11 +248,15 @@ jobs:
                 shell: bash
                 if: runner.os == 'macOS'
                 run: |
-                    brew install autoconf automake
+                    brew install autoconf automake cppunit
 
             -   name: Install Windows tools
                 if: runner.os == 'Windows'
                 uses: "GuillaumeFalourd/setup-rsync@v1.2"
+
+            -   name: Install cppunit (Windows)
+                if: runner.os == 'Windows'
+                run: choco install -y cppunit
 
             -   name: Install LXD (for Snapcraft)
                 if: env.BUILD_SNAP == 'true'

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -46,15 +46,23 @@ jobs:
                 run: |
                     export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 
+            -   name: Install cppunit (Linux)
+                if: runner.os == 'Linux'
+                run: sudo apt-get update && sudo apt-get install -y libcppunit-dev
+
             -   name: Install Mac tools
                 shell: bash
                 if: runner.os == 'macOS'
                 run: |
-                    brew install autoconf automake
+                    brew install autoconf automake cppunit
 
             -   name: Install Windows tools
                 if: runner.os == 'Windows'
                 uses: "GuillaumeFalourd/setup-rsync@v1.2"
+
+            -   name: Install cppunit (Windows)
+                if: runner.os == 'Windows'
+                run: choco install -y cppunit
 
             -   uses: actions/setup-python@v5
                 with:

--- a/.github/workflows/build-squall.yml
+++ b/.github/workflows/build-squall.yml
@@ -54,6 +54,18 @@ jobs:
                 run: |
                     export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
 
+            -   name: Install cppunit (Linux)
+                if: runner.os == 'Linux'
+                run: sudo apt-get update && sudo apt-get install -y libcppunit-dev
+
+            -   name: Install cppunit (macOS)
+                if: runner.os == 'macOS'
+                run: brew install cppunit
+
+            -   name: Install cppunit (Windows)
+                if: runner.os == 'Windows'
+                run: choco install -y cppunit
+
             -   uses: actions/setup-python@v5
                 with:
                     python-version: '3.10'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(VERSION_FALLBACK "0.9.0-dev")
 if (BUILD_TESTING)
     find_package(cppunit 1.15.1 EXACT QUIET)
     if (NOT cppunit_FOUND)
-        message(WARNING "cppunit 1.15.1 not found. Tests will be skipped.")
+        message(FATAL_ERROR "cppunit 1.15.1 not found. Tests require cppunit to be installed.")
     endif ()
 endif ()
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ and for server scripting.
 ### Dependency setup
 
 Conan provides all third‑party libraries, including runtime components
-like `spdlog` and the `cppunit` test framework. Begin by detecting a
-profile and adding the Worldforge remote, which hosts custom packages
+like `spdlog` and the `cppunit` test framework. If you enable tests by
+setting `-DBUILD_TESTING=ON`, the build will halt if `cppunit` is
+missing. Install it via your system package manager (for example,
+`sudo apt-get install libcppunit-dev` on Debian/Ubuntu or `brew install
+cppunit` on macOS) unless Conan is used to supply it. Begin by detecting
+a profile and adding the Worldforge remote, which hosts custom packages
 such as `ogre-next` and `cegui`. If the remote requires credentials,
 export `CONAN_LOGIN_USERNAME` and `CONAN_PASSWORD` before the install.
 


### PR DESCRIPTION
## Summary
- Fail configuration if `BUILD_TESTING` is enabled and `cppunit` is absent
- Document required `cppunit` installation for test builds
- Install `cppunit` in CI workflows across Linux, macOS, and Windows

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON` *(fails: cppunit 1.15.1 not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb50cc819c832db87b8e2751074124