### PR TITLE
Relax cppunit version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,9 @@ set(VERSION_FALLBACK "0.9.0-dev")
 
 # Only look for cppunit when tests are requested.
 if (BUILD_TESTING)
-    find_package(cppunit 1.15.1 EXACT QUIET)
+    find_package(cppunit 1.15...<2.0 QUIET)
     if (NOT cppunit_FOUND)
-        message(FATAL_ERROR "cppunit 1.15.1 not found. Tests require cppunit to be installed.")
+        message(FATAL_ERROR "cppunit >=1.15 and <2.0 not found. Tests require cppunit to be installed.")
     endif ()
 endif ()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -105,7 +105,7 @@ class Worldforge(ConanFile):
 
         # self.requires("avahi/0.8")
 
-        self.test_requires("cppunit/[>=1.15.1 <2.0]")
+        self.test_requires("cppunit/[>=1.15 <2.0]")
         self.test_requires("catch2/[>=3.8.1 <4.0]")
 
     def generate(self):


### PR DESCRIPTION
## Summary
- allow any cppunit from 1.15 up to but not including 2.0
- match test requirements in Conan recipe with same cppunit range

## Testing
- `conan profile detect --force`
- `conan remote add worldforge https://artifactory.ogenvik.org/artifactory/api/conan/conan-local` *(fails: already exists)*
- `conan install . --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True` *(fails: Requirement 'ogre-next/2.3.0@worldforge' not in lockfile 'requires')*
- `cmake --preset conan-release` *(fails: Invalid preset: "coverage")*
- `cmake --build --preset conan-release --target check` *(fails: Invalid preset: "coverage")*

------
https://chatgpt.com/codex/tasks/task_e_68bb547413d0832db13bd8920ca3ca1d