### PR TITLE
Handle codec errors in Bridge

### DIFF
--- a/libs/atlas/src/Atlas-Python/atlas/transport/bridge.py
+++ b/libs/atlas/src/Atlas-Python/atlas/transport/bridge.py
@@ -118,9 +118,17 @@ class Bridge:
             if self.operations_to_send:
                 msg = atlas.Messages(*self.operations_to_send)
                 self.operations_to_send = []
-                res_str = res_str + self.internal_send_string(self.codec.encode(msg))
+                try:
+                    encoded = self.codec.encode(msg)
+                except Exception as e:
+                    raise BridgeException(f"Encoding failed: {e}") from e
+                res_str = res_str + self.internal_send_string(encoded)
             if op!=None:
-                res_str = res_str + self.internal_send_string(self.codec.encode(op))
+                try:
+                    encoded = self.codec.encode(op)
+                except Exception as e:
+                    raise BridgeException(f"Encoding failed: {e}") from e
+                res_str = res_str + self.internal_send_string(encoded)
             return res_str, atlas.Messages()
         if self.store_operations and op!=None:
             self.operations_to_send.append(op)
@@ -138,10 +146,9 @@ class Bridge:
         try:
             objects = self.codec.decode(data)
             self.log("decode_string", objects)
-        except:
+        except Exception as e:
             self.log("exception in decoding", data)
-            raise
-            #raise BridgeException("Decoding failed")
+            raise BridgeException(f"Decoding failed: {e}") from e
         for op in objects:
             self.operation_received(op)
         return objects

--- a/libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py
+++ b/libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py
@@ -1,0 +1,29 @@
+import pytest
+import atlas
+from atlas.transport.bridge import Bridge, BridgeException
+
+
+class FailingCodec:
+    def encode(self, _):
+        raise ValueError("cannot encode")
+
+    def decode(self, _):
+        raise ValueError("cannot decode")
+
+    def close(self):
+        return ''
+
+
+def test_decode_invalid_data():
+    bridge = Bridge()
+    bridge.codec = FailingCodec()
+    with pytest.raises(BridgeException, match="Decoding failed"):
+        bridge.process_string("bad data")
+
+
+def test_encode_invalid_operation():
+    bridge = Bridge()
+    bridge.codec = FailingCodec()
+    op = atlas.Operation("foo")
+    with pytest.raises(BridgeException, match="Encoding failed"):
+        bridge.process_operation(op)


### PR DESCRIPTION
## Summary
- Raise `BridgeException` when codec encode/decode fails
- Add tests for invalid codec data

## Testing
- `PYTHONPATH=libs/atlas/src/Atlas-Python pytest libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py -q`
- `PYTHONPATH=libs/atlas/src/Atlas-Python pytest libs/atlas/src/Atlas-Python/tests/test_bridge.py -q` *(fails: AttributeError: module 'string' has no attribute 'find')*

------
https://chatgpt.com/codex/tasks/task_e_68bb547eebc0832da31f84fb3d7a6f79