### PR TITLE
Add client-aware server list sorting and filtering

### DIFF
--- a/apps/metaserver/tests/DataObject_unittest.cpp
+++ b/apps/metaserver/tests/DataObject_unittest.cpp
@@ -48,6 +48,7 @@ CPPUNIT_TEST_SUITE(DataObject_unittest);
                 CPPUNIT_TEST(test_ExpireServerSessions);
                 CPPUNIT_TEST(test_ExpireHandshakes);
                 CPPUNIT_TEST(test_ServerSessionSorting);
+               CPPUNIT_TEST(test_ServerSessionFilteringAndSorting);
                 CPPUNIT_TEST(test_MalformedExpiry);
 
 
@@ -329,6 +330,34 @@ public:
                 CPPUNIT_ASSERT(v1 == expected1);
                 CPPUNIT_ASSERT(v2 == expected2);
         }
+
+       void test_ServerSessionFilteringAndSorting() {
+               // Setup server sessions with attributes that can be filtered and
+               // sorted on
+               msdo->addServerSession("server1");
+               msdo->addServerAttribute("server1", "region", "eu");
+               msdo->addServerAttribute("server1", "population", "100");
+               msdo->addServerSession("server2");
+               msdo->addServerAttribute("server2", "region", "us");
+               msdo->addServerAttribute("server2", "population", "200");
+               msdo->addServerSession("server3");
+               msdo->addServerAttribute("server3", "region", "eu");
+               msdo->addServerAttribute("server3", "population", "150");
+
+               // Client filtering for region=eu and sorting by population
+               msdo->addClientAttribute("clientEu", "dummy", "1");
+               msdo->addClientFilter("clientEu", "region", "eu");
+               msdo->addClientFilter("clientEu", "sortby", "population");
+
+               msdo->createServerSessionListresp("clientEu");
+
+               std::list<std::string> list = msdo->getServerSessionList(0, 10, "clientEu");
+               std::vector<std::string> v(list.begin(), list.end());
+
+               std::vector<std::string> expected = {"server1", "server3"};
+
+               CPPUNIT_ASSERT(v == expected);
+       }
 
         void test_MalformedExpiry() {
                 std::string sid = "badexpiry";


### PR DESCRIPTION
## Summary
- add client-aware filtering and sorting lambda before building `ip_list`
- extend DataObject tests with per-client filtering and sorting checks

## Testing
- `g++ -std=c++17 apps/metaserver/src/server/DataObject.cpp apps/metaserver/tests/DataObject_unittest.cpp -Iapps/metaserver/src/server -Iapps/metaserver/tests -lcppunit -lspdlog -lfmt -lboost_date_time -o dataobject_tests`
- `./dataobject_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c6e02f667c832d801cd7ef3b2e238b