### PR TITLE
Ensure MetaServerPacket lifetime in async UDP send

### DIFF
--- a/apps/metaserver/src/server/MetaServerHandlerUDP.hpp
+++ b/apps/metaserver/src/server/MetaServerHandlerUDP.hpp
@@ -30,6 +30,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <memory>
 
 /*
  * Forward Declarations
@@ -50,7 +51,7 @@ public:
 
 	void handle_receive(const boost::system::error_code& error, std::size_t);
 
-        static void handle_send(const MetaServerPacket& p, const boost::system::error_code& error, std::size_t);
+        static void handle_send(const std::shared_ptr<MetaServerPacket>& p, const boost::system::error_code& error, std::size_t);
 
         void process_outbound(const boost::system::error_code& error);
 


### PR DESCRIPTION
## Summary
- capture MetaServerPacket in UDP send callback to ensure buffer lifetime
- adjust handle_send to take shared_ptr and include <memory>

## Testing
- `g++ -std=c++17 -Iapps/metaserver/src/api -Iapps/metaserver/src/server -Iapps/metaserver/src -c apps/metaserver/src/server/MetaServerHandlerUDP.cpp -o /tmp/MetaServerHandlerUDP.o` *(fails: spdlog/spdlog.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0330260832db3b33f087a2bce39