### PR TITLE
Handle Windows home expansion

### DIFF
--- a/apps/metaserver/src/server/MetaServer.cpp
+++ b/apps/metaserver/src/server/MetaServer.cpp
@@ -1213,7 +1213,18 @@ MetaServer::registerConfig(boost::program_options::variables_map& vm) {
 			m_PacketLogfile = "~/.metaserver-ng/packetdefault.bin";
 		}
 
+                // Expand any leading '~' to the user's home directory. On
+                // Windows we resolve this manually as the default helper
+                // expects Unix style paths.
+#ifdef WIN32
+                if (!m_PacketLogfile.empty() && m_PacketLogfile[0] == '~') {
+                        if (const char* envHome = std::getenv("USERPROFILE")) {
+                                m_PacketLogfile = (std::filesystem::path(envHome) / m_PacketLogfile.substr(1)).string();
+                        }
+                }
+#else
                 m_PacketLogfile = expandHome(m_PacketLogfile);
+#endif
 
 	}
 
@@ -1241,8 +1252,19 @@ MetaServer::registerConfig(boost::program_options::variables_map& vm) {
 		 *
 		 * TODO: add ifdef WIN32 here if/when metserver needs to run on windows
 		 */
+                // Expand any leading '~' for the logfile path. Provide a
+                // Windows specific implementation since the general helper
+                // assumes POSIX semantics.
+#ifdef WIN32
+                if (!m_Logfile.empty() && m_Logfile[0] == '~') {
+                        if (const char* envHome = std::getenv("USERPROFILE")) {
+                                m_Logfile = (std::filesystem::path(envHome) / m_Logfile.substr(1)).string();
+                        }
+                }
+#else
                 m_Logfile = expandHome(m_Logfile);
-	}
+#endif
+        }
 
 	if (vm.count("server.pidfile")) {
 		m_pidFile = vm["server.pidfile"].as<std::string>();


### PR DESCRIPTION
## Summary
- add Windows-specific handling when expanding packet and log file paths

## Testing
- `g++ -c apps/metaserver/src/server/MetaServer.cpp -std=c++17 -Iapps/metaserver/src/server -Iapps/metaserver/src/api -Iapps/metaserver/tests -DSYSCONFDIR='"/etc"'`
- `g++ -c apps/metaserver/src/server/MetaServer.cpp -std=c++17 -Iapps/metaserver/src/server -Iapps/metaserver/src/api -Iapps/metaserver/tests -DSYSCONFDIR='"/etc"' -DWIN32` *(fails: winsock2.h: No such file or directory)*
- `g++ apps/metaserver/tests/MetaServer_unittest.cpp apps/metaserver/src/server/MetaServer.cpp apps/metaserver/src/api/MetaServerPacket.cpp apps/metaserver/src/server/DataObject.cpp -std=c++17 -DSYSCONFDIR='"/etc"' -Iapps/metaserver/src/server -Iapps/metaserver/src/api -Iapps/metaserver/tests -I/usr/lib/llvm-18/include -L/usr/lib/llvm-18/lib -lLLVM-18 -fexceptions -lcppunit -lboost_program_options -lspdlog -lfmt -lpthread -o MetaServer_unittest`
- `./MetaServer_unittest` *(fails: testExpandHome)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0340db8832d836950c6efc689e7