### PR TITLE
Handle negotiation failures in Bridge

### DIFF
--- a/libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py
+++ b/libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py
@@ -27,3 +27,33 @@ def test_encode_invalid_operation():
     op = atlas.Operation("foo")
     with pytest.raises(BridgeException, match="Encoding failed"):
         bridge.process_operation(op)
+
+
+class FailingNegotiation:
+    def __init__(self, raise_error=False):
+        self.state = 1 if raise_error else 0
+        self.result_code = "" if raise_error else "fail"
+        self.str = ""
+        self.raise_error = raise_error
+
+    def __call__(self, _):
+        if self.raise_error:
+            raise ValueError("bad negotiation")
+
+    def get_send_str(self):
+        return ""
+
+    def get_codec(self):
+        return FailingCodec()
+
+
+def test_negotiation_fail_state():
+    bridge = Bridge(negotiation=FailingNegotiation())
+    with pytest.raises(BridgeException, match="Negotiation failed"):
+        bridge.process_string("")
+
+
+def test_negotiation_exception():
+    bridge = Bridge(negotiation=FailingNegotiation(raise_error=True))
+    with pytest.raises(BridgeException, match="Negotiation failed: bad negotiation"):
+        bridge.process_string("data")


### PR DESCRIPTION
## Summary
- Raise `BridgeException` when negotiation fails or codec retrieval errors occur
- Update bridge documentation to reflect new error handling
- Extend tests to cover negotiation failure and exception scenarios

## Testing
- `PYTHONPATH=libs/atlas/src/Atlas-Python pytest libs/atlas/src/Atlas-Python/tests/test_bridge_exceptions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e03606a4832da6459c21023af3a1