### PR TITLE
Make path search extent configurable

### DIFF
--- a/apps/cyphesis/src/navigation/Awareness.cpp
+++ b/apps/cyphesis/src/navigation/Awareness.cpp
@@ -822,13 +822,15 @@ void Awareness::findAffectedTiles(const WFMath::AxisBox<2>& area, int& tileMinXI
 
 int Awareness::findPath(const WFMath::Point<3>& start, const WFMath::Point<3>& end, float radius, std::vector<WFMath::Point<3>>& path) const {
 
-	float pStartPos[]{static_cast<float>(start.x()), static_cast<float>(start.y()), static_cast<float>(start.z())};
-	float pEndPos[]{static_cast<float>(end.x()), static_cast<float>(end.y()), static_cast<float>(end.z())};
-	float startExtent[]{5, 100, 5}; //Only extend radius in horizontal plane
-	//To make sure that the agent can move close enough we need to subtract the agent's radius from the destination radius.
-	//We'll also adjust with 0.95 to allow for some padding.
-	//float destinationRadius = (radius - mAgentRadius) * 0.95f;
-	float endExtent[]{5, 100, 5}; //Only extend radius in horizontal plane
+        float pStartPos[]{static_cast<float>(start.x()), static_cast<float>(start.y()), static_cast<float>(start.z())};
+        float pEndPos[]{static_cast<float>(end.x()), static_cast<float>(end.y()), static_cast<float>(end.z())};
+        //Only extend radius in the horizontal plane. If no radius was supplied, fall back to the agent's radius.
+        float horizExtent = radius > 0.f ? radius : mAgentRadius;
+        float startExtent[]{horizExtent, 100, horizExtent};
+        //To make sure that the agent can move close enough we need to subtract the agent's radius from the destination radius.
+        //We'll also adjust with 0.95 to allow for some padding.
+        //float destinationRadius = (radius - mAgentRadius) * 0.95f;
+        float endExtent[]{horizExtent, 100, horizExtent};
 
 
 	dtStatus status;

--- a/apps/cyphesis/src/navigation/Awareness.h
+++ b/apps/cyphesis/src/navigation/Awareness.h
@@ -200,11 +200,12 @@ public:
 	 * @brief Finds a path from the start to the finish.
 	 * @param start A starting position.
 	 * @param end A finish position.
-	 * @param radius The radius of the horizontal search area (kinda; it's not a circle but an axis aligned box)
-	 * @param path The waypoints of the path will be stored here.
-	 * @return The number of waypoints in the path. 0 if no path could be found. A negative values means that something went wrong.
-	 */
-	int findPath(const WFMath::Point<3>& start, const WFMath::Point<3>& end, float radius, std::vector<WFMath::Point<3>>& path) const;
+         * @param radius The radius of the horizontal search area (kinda; it's not a circle but an axis aligned box).
+         *               If set to a value <= 0 the agent's radius will be used instead.
+         * @param path The waypoints of the path will be stored here.
+         * @return The number of waypoints in the path. 0 if no path could be found. A negative values means that something went wrong.
+         */
+        int findPath(const WFMath::Point<3>& start, const WFMath::Point<3>& end, float radius, std::vector<WFMath::Point<3>>& path) const;
 
 	/**
 	 * @brief Process the tile at the specified index.

--- a/apps/cyphesis/src/navigation/Steering.cpp
+++ b/apps/cyphesis/src/navigation/Steering.cpp
@@ -31,6 +31,7 @@
 #include <wfmath/vector.h>
 #include <wfmath/rotbox.h>
 #include <wfmath/segment.h>
+#include <algorithm>
 
 
 static const bool debug_flag = true;
@@ -89,7 +90,8 @@ int Steering::queryDestination(const EntityLocation<MemEntity>& destination, std
         }
 
         std::vector<WFMath::Point<3>> path;
-        return mAwareness->findPath(currentAvatarPos, resolved.position, 0.f, path);
+        //Use the avatar's horizontal radius to determine the search extent when querying a path.
+        return mAwareness->findPath(currentAvatarPos, resolved.position, mAvatarHorizRadius, path);
 }
 
 void Steering::setDestination(SteeringDestination destination, std::chrono::milliseconds currentServerTimestamp) {
@@ -195,7 +197,8 @@ int Steering::updatePath(std::chrono::milliseconds currentTimestamp, const WFMat
 		mPathResult = -8;
 		return mPathResult;
 	}
-	mPathResult = mAwareness->findPath(currentAvatarPosition, resolvedPosition.position, (float) mSteeringDestination.distance, mPath);
+        float searchRadius = std::max(static_cast<float>(mAvatarHorizRadius), static_cast<float>(mSteeringDestination.distance));
+        mPathResult = mAwareness->findPath(currentAvatarPosition, resolvedPosition.position, searchRadius, mPath);
 	if (mPathResult == -1) {
 		mAwareness->markTilesAsDirty(WFMath::AxisBox<2>(
 				{currentAvatarPosition.x() - 5, currentAvatarPosition.z() - 5},

--- a/apps/cyphesis/tests/navigation/SteeringIntegration.cpp
+++ b/apps/cyphesis/tests/navigation/SteeringIntegration.cpp
@@ -25,6 +25,7 @@
 #include "../TestBase.h"
 #include "../TestWorld.h"
 #include "rules/EntityLocation_impl.h"
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -672,6 +673,8 @@ struct SteeringIntegration : public Cyphesis::TestBase {
                 rebuildAllTilesFn();
                 auto result = steering.queryDestination(EntityLocation<MemEntity>(worldEntity, {10, 0, 0}), 0ms);
                 ASSERT_EQUAL(1, result);
+                std::vector<WFMath::Point<3>> path;
+                ASSERT_TRUE(awareness.findPath(WFMath::Point<3>(0, 0, 0), WFMath::Point<3>(10, 0, 0), 1.f, path) > 0);
         }
 
         void test_path_refresh_on_entity_move() {


### PR DESCRIPTION
## Summary
- Use supplied radius or agent size to set navmesh search extents
- Pass avatar radius to path queries and ensure minimum search radius
- Document configurable search radius and add regression test

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find package configuration file provided by "Microsoft.GSL")*

------
https://chatgpt.com/codex/tasks/task_e_68c6e0383d98832d880164eeab07d0aa