### PR TITLE
Implement basic Ogre instancing manager and test

### DIFF
--- a/apps/ember/src/components/ogre/InstancingManager.cpp
+++ b/apps/ember/src/components/ogre/InstancingManager.cpp
@@ -1,21 +1,46 @@
 #include "InstancingManager.h"
 
+#include <OgreSceneManager.h>
+#include <OgreSceneNode.h>
+
 namespace Ember::OgreView {
 
 InstancingManager::InstancingManager() = default;
 
 void InstancingManager::registerMovable(Ogre::MovableObject* obj) {
-    if (obj) {
-        mRegistered.push_back(obj);
+    auto* entity = dynamic_cast<Ogre::Entity*>(obj);
+    if (entity) {
+        mEntries.push_back({entity, nullptr});
     }
 }
 
 void InstancingManager::update() {
-    // Placeholder: in a full implementation this would build GPU instance
-    // buffers and issue indirect draw calls. For now we simply ensure that
-    // the objects remain valid.
-    for (auto* obj : mRegistered) {
-        (void)obj;
+    if (mEntries.empty()) {
+        return;
+    }
+
+    if (!mInstanceManager) {
+        Ogre::Entity* base = mEntries.front().source;
+        Ogre::SceneManager* sceneMgr = base->getSceneManager();
+        const Ogre::String& meshName = base->getMesh()->getName();
+        mInstanceManager = sceneMgr->createInstanceManager(
+                meshName + "/InstancingManager", meshName, base->getMesh()->getGroup(),
+                Ogre::InstanceManager::HWInstancingBasic);
+    }
+
+    for (auto& entry : mEntries) {
+        if (!entry.instanced) {
+            const Ogre::String& matName = entry.source->getSubEntity(0)->getMaterialName();
+            entry.instanced = mInstanceManager->createInstancedEntity(matName);
+            if (auto* node = entry.source->getParentSceneNode()) {
+                node->attachObject(entry.instanced);
+            }
+            entry.source->setVisible(false);
+        }
+    }
+
+    if (mInstanceManager) {
+        mInstanceManager->_updateDirtyBatches();
     }
 }
 

--- a/apps/ember/src/components/ogre/InstancingManager.h
+++ b/apps/ember/src/components/ogre/InstancingManager.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "OgreIncludes.h"
-#include <OgreMovableObject.h>
+#include <OgreEntity.h>
+#include <OgreInstanceManager.h>
+#include <OgreInstancedEntity.h>
 #include <vector>
 
 namespace Ember::OgreView {
@@ -19,11 +21,17 @@ public:
     /** Register a movable object for instanced rendering. */
     void registerMovable(Ogre::MovableObject* obj);
 
-    /** Update instancing buffers (placeholder). */
+    /** Build and upload instance buffers. */
     void update();
 
 private:
-    std::vector<Ogre::MovableObject*> mRegistered;
+    struct Entry {
+        Ogre::Entity* source;
+        Ogre::InstancedEntity* instanced{nullptr};
+    };
+
+    std::vector<Entry> mEntries;
+    Ogre::InstanceManager* mInstanceManager{nullptr};
 };
 
 } // namespace Ember::OgreView

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ if (TARGET cppunit::cppunit)
             ModelMountTestCase.cpp
             NestedEntityTestCase.cpp
             AvatarMovementTestCase.cpp
+            InstancingRenderTestCase.cpp
             $<TARGET_OBJECTS:ember-ogre>
             $<TARGET_OBJECTS:ember-caelum>
             $<TARGET_OBJECTS:ember-meshtree>

--- a/apps/ember/tests/InstancingRenderTestCase.cpp
+++ b/apps/ember/tests/InstancingRenderTestCase.cpp
@@ -1,0 +1,62 @@
+#include "InstancingRenderTestCase.h"
+#include "components/ogre/InstancingManager.h"
+#include "components/ogre/SimpleRenderContext.h"
+
+#include <Ogre.h>
+#include <vector>
+
+using namespace Ember::OgreView;
+
+namespace Ember {
+
+void InstancingRenderTestCase::testInstancedBoxes() {
+    Ogre::Root root;
+    Ogre::ResourceGroupManager::getSingleton().addResourceLocation(
+        "../../../../apps/ember/data/assets", "FileSystem");
+    Ogre::ResourceGroupManager::getSingleton().initialiseAllResourceGroups();
+
+    SimpleRenderContext ctx("InstancingTest", 64, 64);
+    Ogre::SceneManager* sm = ctx.getSceneManager();
+    Ogre::SceneNode* rootNode = ctx.getSceneNode();
+
+    Ogre::Entity* e1 = sm->createEntity("box1", "common/primitives/model/box.mesh");
+    Ogre::SceneNode* n1 = rootNode->createChildSceneNode();
+    n1->attachObject(e1);
+    n1->setPosition(0, 0, 0);
+
+    Ogre::Entity* e2 = sm->createEntity("box2", "common/primitives/model/box.mesh");
+    Ogre::SceneNode* n2 = rootNode->createChildSceneNode();
+    n2->attachObject(e2);
+    n2->setPosition(10, 0, 0);
+
+    InstancingManager inst;
+    inst.registerMovable(e1);
+    inst.registerMovable(e2);
+    inst.update();
+
+    ctx.getRenderTexture()->update();
+
+    auto iter = sm->getMovableObjectIterator("InstancedEntity");
+    std::vector<Ogre::Vector3> positions;
+    while (iter.hasMoreElements()) {
+        auto* mo = iter.getNext();
+        auto* instEnt = static_cast<Ogre::InstancedEntity*>(mo);
+        positions.push_back(instEnt->getParentNode()->_getDerivedPosition());
+    }
+
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(2), positions.size());
+    bool foundOrigin = false;
+    bool foundOffset = false;
+    for (const auto& p : positions) {
+        if (p == Ogre::Vector3(0, 0, 0)) {
+            foundOrigin = true;
+        }
+        if (p == Ogre::Vector3(10, 0, 0)) {
+            foundOffset = true;
+        }
+    }
+    CPPUNIT_ASSERT(foundOrigin && foundOffset);
+}
+
+} // namespace Ember
+

--- a/apps/ember/tests/InstancingRenderTestCase.h
+++ b/apps/ember/tests/InstancingRenderTestCase.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace Ember {
+class InstancingRenderTestCase : public CppUnit::TestFixture {
+    CPPUNIT_TEST_SUITE(InstancingRenderTestCase);
+    CPPUNIT_TEST(testInstancedBoxes);
+    CPPUNIT_TEST_SUITE_END();
+public:
+    void testInstancedBoxes();
+};
+} // namespace Ember
+

--- a/apps/ember/tests/TestOgreView.cpp
+++ b/apps/ember/tests/TestOgreView.cpp
@@ -10,10 +10,12 @@ CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::NestedEntityTestCase );
 
 #include "AvatarMovementTestCase.h"
+#include "InstancingRenderTestCase.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ConvertTestCase);
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::AvatarMovementTestCase );
+CPPUNIT_TEST_SUITE_REGISTRATION( Ember::InstancingRenderTestCase );
 
 int main(int argc, char** argv) {
 	CppUnit::TextUi::TestRunner runner;


### PR DESCRIPTION
## Summary
- build GPU instance batches for registered Ogre entities
- update instance buffers via Ogre's instancing API
- add render test that instantiates two boxes

## Testing
- ⚠️ `cmake -S . -B build` *(failed: Could NOT find Boost / sigc++-3)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f12a6394832d8a6b74671a84334f