### PR TITLE
Add axis-based rotation to entity mover

### DIFF
--- a/apps/ember/src/components/ogre/authoring/EntityMoverBase.cpp
+++ b/apps/ember/src/components/ogre/authoring/EntityMoverBase.cpp
@@ -130,8 +130,13 @@ void EntityMoverBase::move(const WFMath::Vector<3>& directionVector) {
 	}
 }
 
-void EntityMoverBase::setRotation(int /*axis*/, WFMath::CoordType /*angle*/) {
-	//not implemented yet
+void EntityMoverBase::setRotation(int axis, WFMath::CoordType angle) {
+        if (axis < 0 || axis > 2 || !std::isfinite(angle)) {
+                return;
+        }
+        WFMath::Quaternion rotation;
+        rotation.rotation(axis, angle);
+        setOrientation(rotation * getOrientation());
 }
 
 void EntityMoverBase::yaw(WFMath::CoordType angle) {

--- a/apps/ember/src/components/ogre/scripting/bindings/lua/LuaAuthoringManager.cpp
+++ b/apps/ember/src/components/ogre/scripting/bindings/lua/LuaAuthoringManager.cpp
@@ -38,11 +38,21 @@ void registerLua<AuthoringManager>(sol::table& space) {
 	authoringManager["startMovement"] = &AuthoringManager::startMovement;
 	authoringManager["stopMovement"] = &AuthoringManager::stopMovement;
 
-	auto entityMoveManager = space.new_usertype<EntityMoveManager>("EntityMoveManager", sol::no_constructor);
-	entityMoveManager["startMove"] = &EntityMoveManager::startMove;
-	entityMoveManager["EventStartMoving"] = LuaConnector::make_property(&EntityMoveManager::EventStartMoving);
-	entityMoveManager["EventFinishedMoving"] = LuaConnector::make_property(&EntityMoveManager::EventFinishedMoving);
-	entityMoveManager["EventCancelledMoving"] = LuaConnector::make_property(&EntityMoveManager::EventCancelledMoving);
+        auto entityMoveManager = space.new_usertype<EntityMoveManager>("EntityMoveManager", sol::no_constructor);
+        entityMoveManager["startMove"] = &EntityMoveManager::startMove;
+        entityMoveManager["EventStartMoving"] = LuaConnector::make_property(&EntityMoveManager::EventStartMoving);
+        entityMoveManager["EventFinishedMoving"] = LuaConnector::make_property(&EntityMoveManager::EventFinishedMoving);
+        entityMoveManager["EventCancelledMoving"] = LuaConnector::make_property(&EntityMoveManager::EventCancelledMoving);
+
+        auto entityMover = space.new_usertype<EntityMover>("EntityMover", sol::no_constructor);
+        entityMover["setPosition"] = &EntityMover::setPosition;
+        entityMover["getPosition"] = &EntityMover::getPosition;
+        entityMover["move"] = &EntityMover::move;
+        entityMover["setOrientation"] = &EntityMover::setOrientation;
+        entityMover["setRotation"] = &EntityMover::setRotation;
+        entityMover["yaw"] = &EntityMover::yaw;
+        entityMover["finalizeMovement"] = &EntityMover::finalizeMovement;
+        entityMover["cancelMovement"] = &EntityMover::cancelMovement;
 
 	auto entityRecipe = space.new_usertype<EntityRecipe>("EntityRecipe", sol::no_constructor);
 	entityRecipe["setAuthor"] = &EntityRecipe::setAuthor;

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ if (TARGET cppunit::cppunit)
             ModelMountTestCase.cpp
             NestedEntityTestCase.cpp
             AvatarMovementTestCase.cpp
+            EntityMoverRotationTestCase.cpp
             $<TARGET_OBJECTS:ember-ogre>
             $<TARGET_OBJECTS:ember-caelum>
             $<TARGET_OBJECTS:ember-meshtree>

--- a/apps/ember/tests/EntityMoverRotationTestCase.cpp
+++ b/apps/ember/tests/EntityMoverRotationTestCase.cpp
@@ -1,0 +1,54 @@
+#include "EntityMoverRotationTestCase.h"
+#include "components/ogre/authoring/EntityMoverBase.h"
+#include "components/ogre/Convert.h"
+#include <Ogre.h>
+#include <Eris/Entity.h>
+#include <Atlas/Message/Element.h>
+#include <wfmath/numeric_constants.h>
+
+using namespace Ember::OgreView;
+using namespace Ember::OgreView::Authoring;
+
+namespace Ember {
+
+class DummyEntity : public Eris::Entity {
+public:
+        DummyEntity() : Eris::Entity("0", nullptr) {}
+        Eris::TypeService* getTypeService() const override { return nullptr; }
+        void removeFromMovementPrediction() override {}
+        void addToMovementPrediction() override {}
+        Eris::Entity* getEntity(const std::string& /*id*/) override { return nullptr; }
+        void setAttr(const std::string& p, const Atlas::Message::Element& v) override {
+                Eris::Entity::setAttr(p, v);
+        }
+        void setFromMessage(const Atlas::Message::MapType& attrs) override {
+                Eris::Entity::setFromMessage(attrs);
+        }
+};
+
+class TestMover : public EntityMoverBase {
+public:
+        TestMover(Eris::Entity* entity, Ogre::Node* node, Ogre::SceneManager& sm)
+                : EntityMoverBase(entity, node, sm) {}
+        void finalizeMovement() override {}
+        void cancelMovement() override {}
+};
+
+void EntityMoverRotationTestCase::testRotationAroundAxis() {
+        Ogre::Root root;
+        auto* sceneManager = root.createSceneManager(Ogre::DefaultSceneManagerFactory::FACTORY_TYPE_NAME);
+        auto* node = sceneManager->getRootSceneNode()->createChildSceneNode();
+
+        DummyEntity entity;
+        TestMover mover(&entity, node, *sceneManager);
+
+        WFMath::CoordType angle = WFMath::numeric_constants<WFMath::CoordType>::pi() / 2;
+        mover.setRotation(1, angle);
+
+        WFMath::Quaternion expected;
+        expected.rotation(1, angle);
+        auto orientation = mover.getOrientation();
+        CPPUNIT_ASSERT(orientation.isEqualTo(expected, 0.0001));
+}
+
+} // namespace Ember

--- a/apps/ember/tests/EntityMoverRotationTestCase.h
+++ b/apps/ember/tests/EntityMoverRotationTestCase.h
@@ -1,0 +1,11 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace Ember {
+class EntityMoverRotationTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(EntityMoverRotationTestCase);
+        CPPUNIT_TEST(testRotationAroundAxis);
+        CPPUNIT_TEST_SUITE_END();
+public:
+        void testRotationAroundAxis();
+};
+}

--- a/apps/ember/tests/TestOgreView.cpp
+++ b/apps/ember/tests/TestOgreView.cpp
@@ -10,10 +10,12 @@ CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::NestedEntityTestCase );
 
 #include "AvatarMovementTestCase.h"
+#include "EntityMoverRotationTestCase.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ConvertTestCase);
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::AvatarMovementTestCase );
+CPPUNIT_TEST_SUITE_REGISTRATION( Ember::EntityMoverRotationTestCase );
 
 int main(int argc, char** argv) {
 	CppUnit::TextUi::TestRunner runner;


### PR DESCRIPTION
## Summary
- rotate entities around arbitrary axes using `EntityMoverBase::setRotation`
- expose entity rotation controls to Lua scripting
- add regression test for entity mover rotation

## Testing
- `cmake ..` *(fails: Could NOT find Boost and sigc++-3 packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f12e7cf0832dabf809e1c16eb625