### PR TITLE
Use cstdint for 64-bit polyrefs

### DIFF
--- a/external/RecastDetour/Detour/Include/DetourNavMesh.h
+++ b/external/RecastDetour/Detour/Include/DetourNavMesh.h
@@ -28,10 +28,7 @@
 //#define DT_POLYREF64 1
 
 #ifdef DT_POLYREF64
-// TODO: figure out a multiplatform version of uint64_t
-// - maybe: https://code.google.com/p/msinttypes/
-// - or: http://www.azillionmonkeys.com/qed/pstdint.h
-#include <stdint.h>
+#include <cstdint> // Provides uint64_t across supported platforms
 #endif
 
 // Note: If you want to use 64-bit refs, change the types of both dtPolyRef & dtTileRef.


### PR DESCRIPTION
## Summary
- ensure uint64_t availability for 64-bit polygon references by including `<cstdint>`

## Testing
- `g++ -std=c++17 -Iexternal/RecastDetour/Detour/Include -DDT_POLYREF64 -c /tmp/test.cpp -o /tmp/test.o`
- `g++ -std=c++17 -Iexternal/RecastDetour/Detour/Include -c /tmp/test.cpp -o /tmp/test.o`

------
https://chatgpt.com/codex/tasks/task_e_68c6f96e9efc832d9502866c4830ce3f