### PR TITLE
Log expired sessions and test client expiration data

### DIFF
--- a/apps/metaserver/src/server/MetaServer.cpp
+++ b/apps/metaserver/src/server/MetaServer.cpp
@@ -136,30 +136,39 @@ MetaServer::expiry_timer(const boost::system::error_code&) {
 	boost::posix_time::ptime etime;
 	std::map<std::string, std::string>::iterator attr_iter;
 
-	/*
-	 * Remove handshakes that are older than threshold
-	 * TODO: returned vector shows removed
-	 */
-	std::vector<unsigned int> expiredHS = msdo.expireHandshakes(m_handshakeExpirySeconds);
-	if (!expiredHS.empty()) {
-		spdlog::trace("Expiry Handshakes: {}", expiredHS.size());
-	}
+        /*
+         * Remove handshakes that are older than threshold
+         * and log the removed handshake identifiers
+         */
+        std::vector<unsigned int> expiredHS = msdo.expireHandshakes(m_handshakeExpirySeconds);
+        if (!expiredHS.empty()) {
+                spdlog::trace("Expiry Handshakes: {}", expiredHS.size());
+                for (auto hs : expiredHS) {
+                        spdlog::trace("  expired handshake {}", hs);
+                }
+        }
 
 	/*
 	 * Sweep for server sessions ... expire any that are older than m_sessionExpirySeconds
 	 */
-	std::vector<std::string> expiredSS = msdo.expireServerSessions(m_sessionExpirySeconds);
-	if (!expiredSS.empty()) {
-		spdlog::trace("Expiry ServerSessions: {}", expiredSS.size());
-	}
+        std::vector<std::string> expiredSS = msdo.expireServerSessions(m_sessionExpirySeconds);
+        if (!expiredSS.empty()) {
+                spdlog::trace("Expiry ServerSessions: {}", expiredSS.size());
+                for (const auto& ss : expiredSS) {
+                        spdlog::trace("  expired server session {}", ss);
+                }
+        }
 
 	/**
 	 *  Remove client sessions that are expired
 	 */
-	std::vector<std::string> expiredCS = msdo.expireClientSessions(m_clientExpirySeconds);
-	if (!expiredCS.empty()) {
-		spdlog::trace("Expiry ClientSessions: {}", expiredCS.size());
-	}
+        std::vector<std::string> expiredCS = msdo.expireClientSessions(m_clientExpirySeconds);
+        if (!expiredCS.empty()) {
+                spdlog::trace("Expiry ClientSessions: {}", expiredCS.size());
+                for (const auto& cs : expiredCS) {
+                        spdlog::trace("  expired client session {}", cs);
+                }
+        }
 
 	/*
 	 * We want to purge any cache items that are missing
@@ -167,6 +176,9 @@ MetaServer::expiry_timer(const boost::system::error_code&) {
         std::vector<std::string> expiredCSC = msdo.expireClientSessionCache(m_serverClientCacheExpirySeconds);
         if (!expiredCSC.empty()) {
                 spdlog::trace("Expiry ClientSession Cache: {}", expiredCSC.size());
+                for (const auto& csc : expiredCSC) {
+                        spdlog::trace("  expired cache entry {}", csc);
+                }
         }
 
 	/**

--- a/apps/metaserver/tests/DataObject_unittest.cpp
+++ b/apps/metaserver/tests/DataObject_unittest.cpp
@@ -45,6 +45,7 @@ CPPUNIT_TEST_SUITE(DataObject_unittest);
                 CPPUNIT_TEST(test_Handshake);
                 CPPUNIT_TEST(test_ServerSession);
                 CPPUNIT_TEST(test_ClientSession);
+                CPPUNIT_TEST(test_ExpireClientSessions);
                 CPPUNIT_TEST(test_ExpireServerSessions);
                 CPPUNIT_TEST(test_ExpireHandshakes);
                 CPPUNIT_TEST(test_ServerSessionSorting);
@@ -266,21 +267,30 @@ public:
 
 		// get session, then check that the expected session key exists
 		// and that it matches
-		sess = msdo->getClientSession("123123");
-		CPPUNIT_ASSERT(!sess.empty());
-		CPPUNIT_ASSERT(sess.find("ip") != sess.end());
-		CPPUNIT_ASSERT(sess["ip"] == "123123");
+                sess = msdo->getClientSession("123123");
+                CPPUNIT_ASSERT(!sess.empty());
+                CPPUNIT_ASSERT(sess.find("ip") != sess.end());
+                CPPUNIT_ASSERT(sess["ip"] == "123123");
 
-		// remove session
-		msdo->removeClientSession("123123");
+                // remove session
+                msdo->removeClientSession("123123");
 
-		// get empty session
-		sess_b = msdo->getClientSession("123123");
-		CPPUNIT_ASSERT(sess_b.empty());
+                // get empty session
+                sess_b = msdo->getClientSession("123123");
+                CPPUNIT_ASSERT(sess_b.empty());
 
-		// negative check for session again
+                // negative check for session again
                 CPPUNIT_ASSERT(msdo->clientSessionExists("123123") == false);
 
+        }
+
+        void test_ExpireClientSessions() {
+                msdo->addClientSession("expired1");
+                msdo->addClientSession("expired2");
+                std::vector<std::string> expired = msdo->expireClientSessions(0);
+                CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(2), expired.size());
+                CPPUNIT_ASSERT(std::find(expired.begin(), expired.end(), std::string("expired1")) != expired.end());
+                CPPUNIT_ASSERT(msdo->clientSessionExists("expired1") == false);
         }
 
         void test_ExpireServerSessions() {


### PR DESCRIPTION
## Summary
- Log identifiers of handshakes, server sessions, client sessions, and cache entries removed during expiry
- Document handshake expiry behavior and add test for client session expiry results

## Testing
- `./DataObject_unittest`

------
https://chatgpt.com/codex/tasks/task_e_68c6f990b0f4832da648e835a4b93222