### PR TITLE
Remove numVerts from Recast APIs

### DIFF
--- a/apps/cyphesis/src/navigation/Awareness.cpp
+++ b/apps/cyphesis/src/navigation/Awareness.cpp
@@ -1160,8 +1160,7 @@ int Awareness::rasterizeTileLayers(const std::vector<WFMath::RotBox<2>>& entityA
 
 	float* verts = vertsVector.data();
 	int* tris = trisVector.data();
-	const int nverts = vertsVector.size() / 3;
-	const int ntris = trisVector.size() / 3;
+       const int ntris = trisVector.size() / 3;
 
 // Allocate voxel heightfield where we rasterize our input data to.
 	rc.solid = rcAllocHeightfield();
@@ -1187,11 +1186,11 @@ int Awareness::rasterizeTileLayers(const std::vector<WFMath::RotBox<2>>& entityA
 	memset(rc.triareas, 0, ntris * sizeof(unsigned char));
 	{
 		rmt_ScopedCPUSample(rcMarkWalkableTriangles, 0)
-		rcMarkWalkableTriangles(mCtx.get(), tcfg.walkableSlopeAngle, verts, nverts, tris, ntris, rc.triareas);
+                rcMarkWalkableTriangles(mCtx.get(), tcfg.walkableSlopeAngle, verts, tris, ntris, rc.triareas);
 	}
 	{
 		rmt_ScopedCPUSample(rcRasterizeTriangles, 0)
-		rcRasterizeTriangles(mCtx.get(), verts, nverts, tris, rc.triareas, ntris, *rc.solid, tcfg.walkableClimb);
+                rcRasterizeTriangles(mCtx.get(), verts, tris, rc.triareas, ntris, *rc.solid, tcfg.walkableClimb);
 	}
 // Once all geometry is rasterized, we do initial pass of filtering to
 // remove unwanted overhangs caused by the conservative rasterization

--- a/apps/ember/src/components/navigation/Awareness.cpp
+++ b/apps/ember/src/components/navigation/Awareness.cpp
@@ -896,8 +896,7 @@ int Awareness::rasterizeTileLayers(const std::vector<WFMath::RotBox<2>>& entityA
 
 	float* verts = vertsVector.data();
 	int* tris = trisVector.data();
-	auto nverts = vertsVector.size() / 3;
-	auto ntris = trisVector.size() / 3;
+    auto ntris = trisVector.size() / 3;
 
 // Allocate voxel heightfield where we rasterize our input data to.
 	rc.solid = rcAllocHeightfield();
@@ -918,9 +917,9 @@ int Awareness::rasterizeTileLayers(const std::vector<WFMath::RotBox<2>>& entityA
 	}
 
 	memset(rc.triareas, 0, ntris * sizeof(unsigned char));
-	rcMarkWalkableTriangles(mCtx.get(), tcfg.walkableSlopeAngle, verts, nverts, tris, ntris, rc.triareas);
+    rcMarkWalkableTriangles(mCtx.get(), tcfg.walkableSlopeAngle, verts, tris, ntris, rc.triareas);
 
-	rcRasterizeTriangles(mCtx.get(), verts, nverts, tris, rc.triareas, ntris, *rc.solid, tcfg.walkableClimb);
+    rcRasterizeTriangles(mCtx.get(), verts, tris, rc.triareas, ntris, *rc.solid, tcfg.walkableClimb);
 
 // Once all geometry is rasterized, we do initial pass of filtering to
 // remove unwanted overhangs caused by the conservative rasterization

--- a/external/RecastDetour/Recast/Include/Recast.h
+++ b/external/RecastDetour/Recast/Include/Recast.h
@@ -816,10 +816,9 @@ inline void rcVnormalize(float* v)
 /// Calculates the bounding box of an array of vertices.
 /// @ingroup recast
 /// @param[in]		verts		An array of vertices. [(x, y, z) * @p nv]
-/// @param[in]		numVerts	The number of vertices in the @p verts array.
 /// @param[out]		minBounds	The minimum bounds of the AABB. [(x, y, z)] [Units: wu]
 /// @param[out]		maxBounds	The maximum bounds of the AABB. [(x, y, z)] [Units: wu]
-void rcCalcBounds(const float* verts, int numVerts, float* minBounds, float* maxBounds);
+void rcCalcBounds(const float* verts, float* minBounds, float* maxBounds);
 
 /// Calculates the grid size based on the bounding box and grid cell size.
 /// @ingroup recast
@@ -864,11 +863,10 @@ bool rcCreateHeightfield(rcContext* context, rcHeightfield& heightfield, int siz
 /// @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
 /// 									[Limits: 0 <= value < 90] [Units: Degrees]
 /// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-/// @param[in]		numVerts			The number of vertices.
 /// @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
 /// @param[in]		numTris				The number of triangles.
 /// @param[out]		triAreaIDs			The triangle area ids. [Length: >= @p nt]
-void rcMarkWalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts, int numVerts,
+void rcMarkWalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts,
 							 const int* tris, int numTris, unsigned char* triAreaIDs); 
 
 /// Sets the area id of all triangles with a slope greater than or equal to the specified value to #RC_NULL_AREA.
@@ -885,11 +883,10 @@ void rcMarkWalkableTriangles(rcContext* context, float walkableSlopeAngle, const
 /// @param[in]		walkableSlopeAngle	The maximum slope that is considered walkable.
 /// 									[Limits: 0 <= value < 90] [Units: Degrees]
 /// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-/// @param[in]		numVerts			The number of vertices.
 /// @param[in]		tris				The triangle vertex indices. [(vertA, vertB, vertC) * @p nt]
 /// @param[in]		numTris				The number of triangles.
 /// @param[out]		triAreaIDs			The triangle area ids. [Length: >= @p nt]
-void rcClearUnwalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts, int numVerts,
+void rcClearUnwalkableTriangles(rcContext* context, float walkableSlopeAngle, const float* verts,
 								const int* tris, int numTris, unsigned char* triAreaIDs); 
 
 /// Adds a span to the specified heightfield.
@@ -944,7 +941,6 @@ bool rcRasterizeTriangle(rcContext* context,
 /// @ingroup recast
 /// @param[in,out]	context				The build context to use during the operation.
 /// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-/// @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
 /// @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
 /// @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
 /// @param[in]		numTris				The number of triangles.
@@ -953,7 +949,7 @@ bool rcRasterizeTriangle(rcContext* context,
 ///										[Limit: >= 0] [Units: vx]
 /// @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, int numVerts,
+                          const float* verts,
                           const int* tris, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 
@@ -965,7 +961,6 @@ bool rcRasterizeTriangles(rcContext* context,
 /// @ingroup recast
 /// @param[in,out]	context				The build context to use during the operation.
 /// @param[in]		verts				The vertices. [(x, y, z) * @p nv]
-/// @param[in]		numVerts			The number of vertices. (unused) TODO (graham): Remove in next major release
 /// @param[in]		tris				The triangle indices. [(vertA, vertB, vertC) * @p nt]
 /// @param[in]		triAreaIDs			The area id's of the triangles. [Limit: <= #RC_WALKABLE_AREA] [Size: @p nt]
 /// @param[in]		numTris				The number of triangles.
@@ -974,7 +969,7 @@ bool rcRasterizeTriangles(rcContext* context,
 /// 									[Limit: >= 0] [Units: vx]
 /// @returns True if the operation completed successfully.
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, int numVerts,
+                          const float* verts,
                           const unsigned short* tris, const unsigned char* triAreaIDs, int numTris,
                           rcHeightfield& heightfield, int flagMergeThreshold = 1);
 

--- a/external/RecastDetour/Recast/Source/Recast.cpp
+++ b/external/RecastDetour/Recast/Source/Recast.cpp
@@ -284,7 +284,7 @@ rcPolyMeshDetail::rcPolyMeshDetail()
 {
 }
 
-void rcCalcBounds(const float* verts, int numVerts, float* minBounds, float* maxBounds)
+void rcCalcBounds(const float* verts, float* minBounds, float* maxBounds)
 {
 	// Calculate bounding box.
 	rcVcopy(minBounds, verts);
@@ -334,12 +334,11 @@ static void calcTriNormal(const float* v0, const float* v1, const float* v2, flo
 }
 
 void rcMarkWalkableTriangles(rcContext* context, const float walkableSlopeAngle,
-                             const float* verts, const int numVerts,
+                             const float* verts,
                              const int* tris, const int numTris,
                              unsigned char* triAreaIDs)
 {
 	rcIgnoreUnused(context);
-	rcIgnoreUnused(numVerts);
 
 	const float walkableThr = cosf(walkableSlopeAngle / 180.0f * RC_PI);
 
@@ -358,12 +357,11 @@ void rcMarkWalkableTriangles(rcContext* context, const float walkableSlopeAngle,
 }
 
 void rcClearUnwalkableTriangles(rcContext* context, const float walkableSlopeAngle,
-                                const float* verts, int numVerts,
+                                const float* verts,
                                 const int* tris, int numTris,
                                 unsigned char* triAreaIDs)
 {
 	rcIgnoreUnused(context);
-	rcIgnoreUnused(numVerts);
 
 	// The minimum Y value for a face normal of a triangle with a walkable slope.
 	const float walkableLimitY = cosf(walkableSlopeAngle / 180.0f * RC_PI);

--- a/external/RecastDetour/Recast/Source/RecastRasterization.cpp
+++ b/external/RecastDetour/Recast/Source/RecastRasterization.cpp
@@ -476,7 +476,7 @@ bool rcRasterizeTriangle(rcContext* context,
 }
 
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, const int /*nv*/,
+                          const float* verts, 
                           const int* tris, const unsigned char* triAreaIDs, const int numTris,
                           rcHeightfield& heightfield, const int flagMergeThreshold)
 {
@@ -503,7 +503,7 @@ bool rcRasterizeTriangles(rcContext* context,
 }
 
 bool rcRasterizeTriangles(rcContext* context,
-                          const float* verts, const int /*nv*/,
+                          const float* verts, 
                           const unsigned short* tris, const unsigned char* triAreaIDs, const int numTris,
                           rcHeightfield& heightfield, const int flagMergeThreshold)
 {


### PR DESCRIPTION
## Summary
- drop unused `numVerts` parameter from `rcMarkWalkableTriangles`, `rcClearUnwalkableTriangles`, and `rcRasterizeTriangles`
- update sources and docs to match new signatures
- adjust Ember and Cyphesis navigation builders to call updated APIs

## Testing
- `cmake -S . -B build` *(fails: could not find spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f98f9cf0832dbb8a0f13bef8723f