### PR TITLE
Switch to C++23 ranges for asset vector creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.23)
 
 project(Worldforge)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(PREBUILT_DIR "Directory for prebuilt artifacts" "${CMAKE_SOURCE_DIR}/prebuilt")

--- a/apps/cyphesis/src/server/ServerRouting.cpp
+++ b/apps/cyphesis/src/server/ServerRouting.cpp
@@ -161,9 +161,8 @@ void ServerRouting::addToMessage(MapType& omap) const {
 	}
 	omap["entities"] = (Atlas::Message::IntType) m_world.getEntities().size();
 
-	//TODO: Use std::ranges::to when we upgrade to C++23
-	auto assets_view = m_assets | std::views::transform([](auto entry) { return Atlas::Message::Element(entry); });
-	omap["assets"] = std::vector<Atlas::Message::Element>(assets_view.begin(), assets_view.end());
+        auto assets_view = m_assets | std::views::transform([](auto entry) { return Atlas::Message::Element(entry); });
+        omap["assets"] = assets_view | std::ranges::to<std::vector>();
 
 	// We could add all sorts of stats here, but I don't know exactly what yet.
 }
@@ -184,9 +183,8 @@ void ServerRouting::addToEntity(const RootEntity& ent) const {
 	}
 	ent->setAttr("entities", (Atlas::Message::IntType) m_world.getEntities().size());
 
-	//TODO: Use std::ranges::to when we upgrade to C++23
-	auto assets_view = m_assets | std::views::transform([](auto entry) { return Atlas::Message::Element(entry); });
-	ent->setAttr("assets", std::vector<Atlas::Message::Element>(assets_view.begin(), assets_view.end()));
+        auto assets_view = m_assets | std::views::transform([](auto entry) { return Atlas::Message::Element(entry); });
+        ent->setAttr("assets", assets_view | std::ranges::to<std::vector>());
 
 	// We could add all sorts of stats here, but I don't know exactly what yet.
 }

--- a/libs/squall/tools/conan/test_package/CMakeLists.txt
+++ b/libs/squall/tools/conan/test_package/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PackageTest CXX)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 find_package(squall CONFIG REQUIRED)


### PR DESCRIPTION
## Summary
- use `std::ranges::to<std::vector>` for asset serialization in `ServerRouting`
- enable C++23 across the project

## Testing
- `conan install . --output-folder=build --build=missing -o with_client=False`
- `cmake -S . -B build/build/Release -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=build/build/Release/generators/conan_toolchain.cmake --log-level=ERROR` *(fails: plain signature already used for target_link_libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f990c420832da4d3b12f14b8164e