### PR TITLE
Use injected height provider for movement decal

### DIFF
--- a/apps/ember/src/components/ogre/MovementController.h
+++ b/apps/ember/src/components/ogre/MovementController.h
@@ -51,6 +51,8 @@ class Steering;
 }
 namespace OgreView {
 
+Ogre::Vector3 projectPointOntoTerrain(IHeightProvider& heightProvider, const Ogre::Vector3& point);
+
 namespace Authoring {
 class AwarenessVisualizer;
 }
@@ -179,10 +181,15 @@ public:
 
 protected:
 
-	/**
-	 * @brief The main camera.
-	 */
-	Camera::MainCamera& mCamera;
+        /**
+         * @brief Provides terrain height information for placement helpers.
+         */
+        IHeightProvider& mHeightProvider;
+
+        /**
+         * @brief The main camera.
+         */
+        Camera::MainCamera& mCamera;
 
 	InputCommandMapper mMovementCommandMapper;
 

--- a/apps/ember/tests/CMakeLists.txt
+++ b/apps/ember/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ if (TARGET cppunit::cppunit)
             NestedEntityTestCase.cpp
             AvatarMovementTestCase.cpp
             InstancingRenderTestCase.cpp
+            MovementControllerTestCase.cpp
             $<TARGET_OBJECTS:ember-ogre>
             $<TARGET_OBJECTS:ember-caelum>
             $<TARGET_OBJECTS:ember-meshtree>

--- a/apps/ember/tests/MovementControllerTestCase.cpp
+++ b/apps/ember/tests/MovementControllerTestCase.cpp
@@ -1,0 +1,63 @@
+#include "MovementControllerTestCase.h"
+#include "components/ogre/MovementController.h"
+#include "domain/IHeightProvider.h"
+
+#include <OgreVector3.h>
+
+#include <vector>
+
+using namespace Ember::OgreView;
+
+namespace Ember {
+namespace {
+
+struct MockHeightProvider : IHeightProvider {
+        mutable std::vector<TerrainPosition> queries;
+        bool shouldSucceed = true;
+        float providedHeight = 0.f;
+
+        bool getHeight(const TerrainPosition& atPosition, float& height) const override {
+                queries.push_back(atPosition);
+                if (shouldSucceed) {
+                        height = providedHeight;
+                        return true;
+                }
+                return false;
+        }
+
+        void blitHeights(int, int, int, int, std::vector<float>&) const override {}
+};
+
+} // namespace
+
+void MovementControllerTestCase::testProjectsPointOntoTerrain() {
+        MockHeightProvider provider;
+        provider.shouldSucceed = true;
+        provider.providedHeight = 42.f;
+
+        Ogre::Vector3 point(5.f, 1.f, -3.f);
+        Ogre::Vector3 projected = projectPointOntoTerrain(provider, point);
+
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), provider.queries.size());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.x, provider.queries.front().x(), 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.z, provider.queries.front().y(), 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.x, projected.x, 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(provider.providedHeight, projected.y, 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.z, projected.z, 0.0001);
+}
+
+void MovementControllerTestCase::testKeepsOriginalHeightWhenLookupFails() {
+        MockHeightProvider provider;
+        provider.shouldSucceed = false;
+        provider.providedHeight = 12.f;
+
+        Ogre::Vector3 point(2.f, 7.f, 9.f);
+        Ogre::Vector3 projected = projectPointOntoTerrain(provider, point);
+
+        CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), provider.queries.size());
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.x, projected.x, 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.y, projected.y, 0.0001);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(point.z, projected.z, 0.0001);
+}
+
+} // namespace Ember

--- a/apps/ember/tests/MovementControllerTestCase.h
+++ b/apps/ember/tests/MovementControllerTestCase.h
@@ -1,0 +1,21 @@
+#ifndef EMBER_MOVEMENTCONTROLLERTESTCASE_H
+#define EMBER_MOVEMENTCONTROLLERTESTCASE_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+namespace Ember {
+
+class MovementControllerTestCase : public CppUnit::TestFixture {
+        CPPUNIT_TEST_SUITE(MovementControllerTestCase);
+        CPPUNIT_TEST(testProjectsPointOntoTerrain);
+        CPPUNIT_TEST(testKeepsOriginalHeightWhenLookupFails);
+        CPPUNIT_TEST_SUITE_END();
+
+public:
+        void testProjectsPointOntoTerrain();
+        void testKeepsOriginalHeightWhenLookupFails();
+};
+
+}
+
+#endif // EMBER_MOVEMENTCONTROLLERTESTCASE_H

--- a/apps/ember/tests/TestOgreView.cpp
+++ b/apps/ember/tests/TestOgreView.cpp
@@ -11,11 +11,13 @@ CPPUNIT_TEST_SUITE_REGISTRATION( Ember::NestedEntityTestCase );
 
 #include "AvatarMovementTestCase.h"
 #include "InstancingRenderTestCase.h"
+#include "MovementControllerTestCase.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ConvertTestCase);
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::ModelMountTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::AvatarMovementTestCase );
 CPPUNIT_TEST_SUITE_REGISTRATION( Ember::InstancingRenderTestCase );
+CPPUNIT_TEST_SUITE_REGISTRATION( Ember::MovementControllerTestCase );
 
 int main(int argc, char** argv) {
 	CppUnit::TextUi::TestRunner runner;


### PR DESCRIPTION
## Summary
- store and reuse the injected height provider inside `MovementController`
- project move-to targets onto terrain heights before positioning the decal node
- cover the terrain projection helper with a CppUnit test case using a mock height provider

## Testing
- `conan install . --build missing -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True -s build_type=Release` *(fails: requirement 'ogre-next/2.3.0@worldforge' not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68c9847f5460832db1362e66c4f179bc