### PR TITLE
Harden metaserver IP parsing

### DIFF
--- a/apps/metaserver/tests/MetaServer_unittest.cpp
+++ b/apps/metaserver/tests/MetaServer_unittest.cpp
@@ -261,10 +261,14 @@ public:
 		 */
 		in.setPacketType(NMT_ADMINREQ);
 		in.addPacketData(NMT_ADMINREQ_ADDSERVER);
-		in.addPacketData(IpAsciiToNet("127.0.2.1"));
+                auto packedServer = IpAsciiToNet("127.0.2.1");
+                CPPUNIT_ASSERT(packedServer);
+                in.addPacketData(*packedServer);
 		in.addPacketData(12345);
 
-		in.setAddress("123.123.123.123", IpAsciiToNet("123.123.123.123"));
+                auto packedOrigin = IpAsciiToNet("123.123.123.123");
+                CPPUNIT_ASSERT(packedOrigin);
+                in.setAddress("123.123.123.123", *packedOrigin);
 		in.setPort(11111);
 
 		MetaServer* ms = new MetaServer();


### PR DESCRIPTION
## Summary
- replace the metaserver IP parsing helper with a deterministic implementation that rejects malformed octets and reports failure via `std::optional`
- update the metaserver test server to surface invalid packed server addresses instead of silently packing garbage
- extend the MetaServer packet unit tests with explicit coverage for valid and invalid IPv4 input strings

## Testing
- ⚠️ `cmake -S . -B build -DBUILD_METASERVER_SERVER=ON -DCMAKE_MODULE_PATH=/tmp/cmake` *(fails: CURL 8.10.1 not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd80c1aac0832d89a89f0e5d271200