### PR TITLE
Improve MTRand state deserialization robustness

### DIFF
--- a/libs/wfmath/src/wfmath/randgen.cpp
+++ b/libs/wfmath/src/wfmath/randgen.cpp
@@ -58,11 +58,13 @@
 // Created: 2002-5-23
 
 #include "randgen.h"
-#include <ctime>
+#include <algorithm>
+#include <array>
+#include <climits>
 #include <cstdio>
+#include <ctime>
 #include <istream>
 #include <ostream>
-#include <climits>
 
 namespace WFMath {
 
@@ -203,10 +205,23 @@ std::ostream& MTRand::save(std::ostream& ostr) const {
 
 
 std::istream& MTRand::load(std::istream& istr) {
-	for (auto& i: state)
-		istr >> i;
-	istr >> index;
-	return istr;
+        std::array<uint32, state_size> new_state{};
+        for (auto& value : new_state) {
+                if (!(istr >> value)) {
+                        istr.setstate(std::ios::failbit);
+                        return istr;
+                }
+        }
+
+        uint32 new_index = 0;
+        if (!(istr >> new_index) || new_index >= state_size) {
+                istr.setstate(std::ios::failbit);
+                return istr;
+        }
+
+        std::copy(new_state.begin(), new_state.end(), state);
+        index = new_index;
+        return istr;
 }
 
 }


### PR DESCRIPTION
## Summary
- add validation to `MTRand::load` so generator state is only updated when deserialization succeeds
- introduce round-trip and failure-path unit tests around PRNG save/load behavior
- exercise the new tests via direct calls to the serialization helpers to avoid unrelated dependencies

## Testing
- `g++ -std=c++23 -Ilibs/wfmath/src -I/tmp/Catch2/src -I/tmp/Catch2/extras libs/wfmath/src/wfmath/randgen.cpp libs/wfmath/tests/randgen_test.cpp /tmp/Catch2/extras/catch_amalgamated.cpp -o build/manual/randgen_test -pthread`
- `build/manual/randgen_test`


------
https://chatgpt.com/codex/tasks/task_e_68cdb14ecd38832d9281772b19ed63b1