### PR TITLE
Improve e2e session harness robustness

### DIFF
--- a/apps/tests/e2e/test_minimal_session_utils.py
+++ b/apps/tests/e2e/test_minimal_session_utils.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
+import types
 from pathlib import Path
+
+import pytest
 
 
 _SPEC = importlib.util.spec_from_file_location(
@@ -58,3 +62,97 @@ def test_resolve_build_dir_invalid_override(tmp_path, monkeypatch, capsys):
 
     assert minimal_session._resolve_build_dir("anything") is None
     assert "does not exist" in capsys.readouterr().out
+
+
+class _DummyCursor:
+    def __init__(self, count: int) -> None:
+        self._count = count
+
+    def __enter__(self) -> "_DummyCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        return None
+
+    def execute(self, query: str) -> None:
+        assert query == "SELECT COUNT(*) FROM entities"
+
+    def fetchone(self) -> tuple[int]:
+        return (self._count,)
+
+
+class _DummyConnection:
+    def __init__(self, count: int) -> None:
+        self._count = count
+        self.closed = False
+
+    def __enter__(self) -> "_DummyConnection":  # type: ignore[override]
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+        return None
+
+    def cursor(self) -> _DummyCursor:
+        return _DummyCursor(self._count)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_load_database_drivers_discovers_available_modules(monkeypatch):
+    """Optional database clients should be converted into driver objects."""
+
+    fake_module = types.SimpleNamespace(
+        OperationalError=RuntimeError,
+        connect=lambda dsn, connect_timeout: _DummyConnection(count=1),
+    )
+    monkeypatch.setitem(sys.modules, "psycopg", fake_module)
+
+    drivers = minimal_session._load_database_drivers()
+    assert [driver.name for driver in drivers] == ["psycopg"]
+
+    # The connector should return a usable connection without raising.
+    connection = drivers[0].connect()
+    assert isinstance(connection, _DummyConnection)
+
+
+def test_ensure_database_clean_handles_operational_errors(capsys):
+    """Operational failures should emit diagnostics and continue."""
+
+    driver = minimal_session.DatabaseDriver(
+        name="failing",
+        connect=lambda: (_ for _ in ()).throw(RuntimeError("down")),
+        operational_errors=(RuntimeError,),
+    )
+
+    minimal_session._ensure_database_clean([driver])
+
+    out = capsys.readouterr().out
+    assert "Database unavailable via failing" in out
+    assert "Database check skipped" in out
+
+
+def test_ensure_database_clean_validates_entity_count():
+    """A database with unexpected entities should raise an error."""
+
+    driver = minimal_session.DatabaseDriver(
+        name="dirty",
+        connect=lambda: _DummyConnection(count=2),
+        operational_errors=(RuntimeError,),
+    )
+
+    with pytest.raises(RuntimeError, match="database not clean"):
+        minimal_session._ensure_database_clean([driver])
+
+
+def test_ensure_database_clean_succeeds_for_clean_database():
+    """When a driver succeeds and the database is clean, no output is emitted."""
+
+    driver = minimal_session.DatabaseDriver(
+        name="clean",
+        connect=lambda: _DummyConnection(count=1),
+        operational_errors=(RuntimeError,),
+    )
+
+    minimal_session._ensure_database_clean([driver])


### PR DESCRIPTION
## Summary
- refactor the minimal e2e harness to use structured resource cleanup and explicit helpers
- add reusable database driver discovery and validation logic before the client handshake
- expand unit coverage for the harness utilities, including database checks and optional driver handling

## Testing
- pytest apps/tests/e2e/test_minimal_session_utils.py
- PYTHONPATH=. pytest tools/tests/test_check_dependencies.py

------
https://chatgpt.com/codex/tasks/task_e_68d02c5fc5e0832d9ef086bdd8a631ab