### PR TITLE
Handle signed integers in VarBase

### DIFF
--- a/libs/varconf/src/varconf/variable.cpp
+++ b/libs/varconf/src/varconf/variable.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <cstdlib>
 #include <utility>
+#include <cctype>
 
 namespace varconf {
 
@@ -220,11 +221,24 @@ bool VarBase::is_bool() {
 }
 
 bool VarBase::is_int() {
-	if (!is_string()) return false;
-	for (char i: m_val)
-		if (!isdigit(i))
-			return false;
-	return true;
+        if (!is_string()) return false;
+        if (m_val.empty()) return false;
+
+        std::size_t start = 0;
+        if (m_val[0] == '+' || m_val[0] == '-') {
+                if (m_val.size() == 1) {
+                        return false;
+                }
+                start = 1;
+        }
+
+        for (std::size_t idx = start; idx < m_val.size(); ++idx) {
+                if (!std::isdigit(static_cast<unsigned char>(m_val[idx]))) {
+                        return false;
+                }
+        }
+
+        return true;
 }
 
 bool VarBase::is_double() {

--- a/libs/varconf/tests/CMakeLists.txt
+++ b/libs/varconf/tests/CMakeLists.txt
@@ -1,7 +1,9 @@
 find_package(Catch2 3 REQUIRED)
 
 wf_add_test(conftest.cpp)
+wf_add_test(variable_signedness.cpp)
 
 add_compile_definitions(SRCDIR="${PROJECT_SOURCE_DIR}/tests")
 
 target_link_libraries(conftest PRIVATE Catch2::Catch2WithMain)
+target_link_libraries(variable_signedness PRIVATE Catch2::Catch2WithMain)

--- a/libs/varconf/tests/variable_signedness.cpp
+++ b/libs/varconf/tests/variable_signedness.cpp
@@ -1,0 +1,19 @@
+#include <varconf/varconf.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("VarBase recognizes signed integers", "[varconf]") {
+        varconf::VarBase positive("+123");
+        REQUIRE(positive.is_int());
+        REQUIRE(static_cast<int>(positive) == 123);
+
+        varconf::VarBase negative("-42");
+        REQUIRE(negative.is_int());
+        REQUIRE(static_cast<int>(negative) == -42);
+
+        varconf::VarBase lone_minus("-");
+        REQUIRE_FALSE(lone_minus.is_int());
+
+        varconf::VarBase embedded_sign("12-3");
+        REQUIRE_FALSE(embedded_sign.is_int());
+}


### PR DESCRIPTION
## Summary
- allow `VarBase::is_int` to accept signed numeric strings while rejecting empty or sign-only inputs
- add a dedicated Catch2 test covering signed integer detection and wire it into the Varconf test suite

## Testing
- `g++ -std=c++17 -Ilibs/varconf/src -I/usr/include/sigc++-3.0 -I/usr/lib/x86_64-linux-gnu/sigc++-3.0/include     libs/varconf/tests/variable_signedness.cpp libs/varconf/src/varconf/config.cpp libs/varconf/src/varconf/parse_error.cpp libs/varconf/src/varconf/variable.cpp     -lsigc-3.0 -lCatch2Main -lCatch2 -o libs/varconf/build/variable_signedness -pthread`
- `libs/varconf/build/variable_signedness`

------
https://chatgpt.com/codex/tasks/task_e_68d031ca14d4832db5664d02d0061a5b