### PR TITLE
feat(e2e): allow configuring PostgreSQL DSN

### DIFF
--- a/docs/system_audit_2024-05.md
+++ b/docs/system_audit_2024-05.md
@@ -30,3 +30,7 @@
 
 ## 4. Deployment Impact
 - Documentation-only iteration; no binaries or infrastructure were modified. Deployment posture remains unchanged while providing guidance for subsequent automation.
+
+## 5. Iteration 1 → 2 Transformation Summary
+- Hardened the database health-check harness by allowing the DSN to be supplied via the ``WF_E2E_PG_DSN`` environment variable, ensuring operators can validate Cyphesis deployments against managed PostgreSQL instances while retaining safe defaults for local builds.【F:apps/tests/e2e/minimal_session.py†L32-L40】【F:apps/tests/e2e/minimal_session.py†L120-L149】
+- Added regression tests covering the DSN override semantics so CI environments surface misconfigurations immediately.【F:apps/tests/e2e/test_minimal_session_utils.py†L90-L147】


### PR DESCRIPTION
## Summary
- allow the minimal-session harness to take its PostgreSQL DSN from the `WF_E2E_PG_DSN` environment variable while preserving the local default
- extend the end-to-end helper tests to cover DSN override semantics
- document the iteration in the system audit log

## Testing
- pytest apps/tests/e2e/test_minimal_session_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d03a6cc204832d837d131c2676423b